### PR TITLE
optionsmenu - Fix Main menu button linking to GitHub release page

### DIFF
--- a/addons/optionsmenu/config.cpp
+++ b/addons/optionsmenu/config.cpp
@@ -31,6 +31,7 @@ class CfgAddons {
 
 class CfgCommands {
     allowedHTMLLoadURIs[] += {
-        "https://ace3.acemod.org/version.html"
+        "https://ace3.acemod.org/version.html",
+        "https://github.com/acemod/ACE3/releases"
     };
 };

--- a/addons/optionsmenu/gui/mainMenu.hpp
+++ b/addons/optionsmenu/gui/mainMenu.hpp
@@ -20,8 +20,9 @@ class RscDisplayMain: RscStandardDisplay {
 
         class ACE_news_apex: InfoNews {
             idc = IDC_MAIN_INFO;
+            onLoad = "params ['_ctrl', '_config']; if (productVersion # 8 != '') then {_ctrl ctrlSetPositionY (getNumber (_config >> 'yAlt')); _ctrl ctrlCommit 0}";
             y = "safeZoneY + safeZoneH - (3 * 2 + 1) * (pixelH * pixelGrid * 2) - 4 * (4 * pixelH)";
-
+            yAlt = "safeZoneY + safeZoneH - (4 * 2 + 1) * (pixelH * pixelGrid * 2) - 4 * (4 * pixelH)";
             class Controls: Controls {
                 class Background: Background {};
                 class BackgroundIcon: BackgroundIcon {};


### PR DESCRIPTION
**When merged this pull request will:**
- Whitelist "https://github.com/acemod/ACE3/releases" in allowedHTMLLoadURIs. This has become necessary since last Arma 3 stable update
- Reposition the ACE Changelog button in the main menu dynamically so that it not longer overlaps with the new button introduced for none stable Arma 3 builds (Profiling, Development)

Before Change:
<img width="3840" height="2160" alt="107410_20260413162123_1" src="https://github.com/user-attachments/assets/7bad1a93-5711-41a8-8382-04f8ab468b8d" />

After Change:
<img width="3840" height="2160" alt="107410_20260413161416_1" src="https://github.com/user-attachments/assets/db3f8036-8104-4637-8595-c1fa51c1c799" />

After Change, on Stable (No additional vanilla button)
<img width="3840" height="2160" alt="107410_20260413163419_1" src="https://github.com/user-attachments/assets/ce20cb90-b64c-4c62-8734-816a7eb42f02" />

