### PR TITLE
missile_gbu - Improve HMD display

### DIFF
--- a/addons/missile_gbu/CfgWeapons.hpp
+++ b/addons/missile_gbu/CfgWeapons.hpp
@@ -1,5 +1,9 @@
 class CfgWeapons {
-    class weapon_LGBLauncherBase;
+    class RocketPods;
+    class weapon_LGBLauncherBase: RocketPods {
+        class LoalAltitude;
+    };
+
     class GVAR(12): weapon_LGBLauncherBase {
         displayName = CSTRING(12);
         magazines[] = {
@@ -10,6 +14,10 @@ class CfgWeapons {
             QGVAR(1_PylonMissile_1Rnd_12),
             QGVAR(PylonMissile_Bomb_GBU12_x1),
             QGVAR(PylonRack_Bomb_GBU12_x2)
+        };
+
+        class LoalAltitude: LoalAltitude {
+             displayName = CSTRING(12);
         };
 
         EGVAR(laser,canSelect) = 1; // can ace_laser lock (allows switching laser code)
@@ -23,6 +31,10 @@ class CfgWeapons {
             QGVAR(2Rnd_FAB250),
             QGVAR(1_PylonMissile_1Rnd_FAB250),
             QGVAR(PylonMissile_1Rnd_FAB250)
+        };
+
+        class LoalAltitude: LoalAltitude {
+             displayName = CSTRING(fab250);
         };
 
         EGVAR(laser,canSelect) = 1; // can ace_laser lock (allows switching laser code)


### PR DESCRIPTION
**When merged this pull request will:**
- Previously would show "LOAL" in selected weapon on HMD... Obviously completely useless info when all other ordnance shows weapon name instead

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
