### PR TITLE
Recoil - Add custom recoil shake coef

### DIFF
--- a/addons/recoil/XEH_postInit.sqf
+++ b/addons/recoil/XEH_postInit.sqf
@@ -1,4 +1,7 @@
 #include "script_component.hpp"
 
+// This is too niche to be a setting, but making it not a magic number is good
+GVAR(extraLauncherShake) = 25.0;
+
 // Register fire event handler
 ["ace_firedPlayer", LINKFUNC(camShake)] call CBA_fnc_addEventHandler;

--- a/addons/recoil/XEH_postInit.sqf
+++ b/addons/recoil/XEH_postInit.sqf
@@ -1,6 +1,6 @@
 #include "script_component.hpp"
 
-// This is too niche to be a setting, but making it not a magic number is good
+// This is too niche to be a setting, but making it not just hardcoded is good
 GVAR(extraLauncherShake) = 25.0;
 
 // Register fire event handler

--- a/addons/recoil/XEH_postInit.sqf
+++ b/addons/recoil/XEH_postInit.sqf
@@ -1,7 +1,4 @@
 #include "script_component.hpp"
 
-// This is too niche to be a setting, but making it not just hardcoded is good
-GVAR(extraLauncherShake) = 25.0;
-
 // Register fire event handler
 ["ace_firedPlayer", LINKFUNC(camShake)] call CBA_fnc_addEventHandler;

--- a/addons/recoil/XEH_preInit.sqf
+++ b/addons/recoil/XEH_preInit.sqf
@@ -9,4 +9,8 @@ PREP_RECOMPILE_END;
 
 GVAR(recoilCache) = createHashMap;
 
+// This is too niche to be a setting, but making it not just hardcoded is good
+GVAR(extraLauncherShake) = 25.0;
+
+
 ADDON = true;

--- a/addons/recoil/functions/fnc_camshake.sqf
+++ b/addons/recoil/functions/fnc_camshake.sqf
@@ -48,7 +48,7 @@ private _recoil = GVAR(recoilCache) getOrDefaultCall [_weapon + _muzzle, {
         _recoil = [0, 0];
     };
 
-    private _customShakeCoef = if ((_recoil isNotEqualTo [0, 0]) && (isNumber (configFile >> "CfgRecoils" >> _recoil >> QGVAR(customShakeCoef)))) then {
+    private _customShakeCoef = if (isNumber (configFile >> "CfgRecoils" >> _recoil >> QGVAR(customShakeCoef))) then {
         getNumber (configFile >> "CfgRecoils" >> _recoil >> QGVAR(customShakeCoef))
     } else {
         1

--- a/addons/recoil/functions/fnc_camshake.sqf
+++ b/addons/recoil/functions/fnc_camshake.sqf
@@ -72,7 +72,7 @@ private _powerCoef = RECOIL_COEF * linearConversion [0, 1, random 1, _recoil sel
 if (isWeaponRested _unit) then {_powerMod = _powerMod - 0.07};
 if (isWeaponDeployed _unit) then {_powerMod = _powerMod - 0.11};
 if (_weapon isEqualTo secondaryWeapon _unit) then {
-    _powerCoef = _powerCoef + 25.0;
+    _powerCoef = _powerCoef + GVAR(extraLauncherShake);
 };
 
 private _camshake = [

--- a/addons/recoil/functions/fnc_camshake.sqf
+++ b/addons/recoil/functions/fnc_camshake.sqf
@@ -48,8 +48,8 @@ private _recoil = GVAR(recoilCache) getOrDefaultCall [_weapon + _muzzle, {
         _recoil = [0, 0];
     };
 
-    private _customShakeCoef = if (isArray (configFile >> "CfgRecoils" >> _recoil >> GVAR(customShakeCoef)) then {
-        getArray (configFile >> "CfgRecoils" >> _recoil)
+    private _customShakeCoef = if ((_recoil isNotEqualTo [0, 0]) && (isNumber (configFile >> "CfgRecoils" >> _recoil >> QGVAR(customShakeCoef)) then {
+        getNumber (configFile >> "CfgRecoils" >> _recoil >> QGVAR(customShakeCoef))
     } else {
         1
     };

--- a/addons/recoil/functions/fnc_camshake.sqf
+++ b/addons/recoil/functions/fnc_camshake.sqf
@@ -48,6 +48,14 @@ private _recoil = GVAR(recoilCache) getOrDefaultCall [_weapon + _muzzle, {
         _recoil = [0, 0];
     };
 
+    private _customShakeCoef = if (isArray (configFile >> "CfgRecoils" >> _recoil >> GVAR(customShakeCoef)) then {
+        getArray (configFile >> "CfgRecoils" >> _recoil)
+    } else {
+        1
+    };
+
+    _recoil = _recoil vectorMultiply _customShakeCoef;
+
     TRACE_3("Caching Recoil config",_weapon,_muzzle,_recoil);
 
     // Ensure format is correct

--- a/addons/recoil/functions/fnc_camshake.sqf
+++ b/addons/recoil/functions/fnc_camshake.sqf
@@ -48,11 +48,12 @@ private _recoil = GVAR(recoilCache) getOrDefaultCall [_weapon + _muzzle, {
         _recoil = [0, 0];
     };
 
-    private _customShakeCoef = if ((_recoil isNotEqualTo [0, 0]) && (isNumber (configFile >> "CfgRecoils" >> _recoil >> QGVAR(customShakeCoef)) then {
+    private _customShakeCoef = if ((_recoil isNotEqualTo [0, 0]) && (isNumber (configFile >> "CfgRecoils" >> _recoil >> QGVAR(customShakeCoef))) then {
         getNumber (configFile >> "CfgRecoils" >> _recoil >> QGVAR(customShakeCoef))
     } else {
         1
     };
+
 
     _recoil = _recoil vectorMultiply _customShakeCoef;
 

--- a/addons/recoil/functions/fnc_camshake.sqf
+++ b/addons/recoil/functions/fnc_camshake.sqf
@@ -38,6 +38,12 @@ private _recoil = GVAR(recoilCache) getOrDefaultCall [_weapon + _muzzle, {
         getText (_config >> _muzzle >> "recoil")
     };
 
+    private _customShakeCoef = if (isNumber (configFile >> "CfgRecoils" >> _recoil >> QGVAR(customShakeCoef))) then {
+        getNumber (configFile >> "CfgRecoils" >> _recoil >> QGVAR(customShakeCoef))
+    } else {
+        1
+    };
+
     if (isClass (configFile >> "CfgRecoils" >> _recoil)) then {
         _recoil = getArray (configFile >> "CfgRecoils" >> _recoil >> "kickBack");
 
@@ -46,12 +52,6 @@ private _recoil = GVAR(recoilCache) getOrDefaultCall [_weapon + _muzzle, {
         };
     } else {
         _recoil = [0, 0];
-    };
-
-    private _customShakeCoef = if (isNumber (configFile >> "CfgRecoils" >> _recoil >> QGVAR(customShakeCoef))) then {
-        getNumber (configFile >> "CfgRecoils" >> _recoil >> QGVAR(customShakeCoef))
-    } else {
-        1
     };
 
 

--- a/addons/recoil/functions/fnc_camshake.sqf
+++ b/addons/recoil/functions/fnc_camshake.sqf
@@ -48,11 +48,12 @@ private _recoil = GVAR(recoilCache) getOrDefaultCall [_weapon + _muzzle, {
         _recoil = [0, 0];
     };
 
-    private _customShakeCoef = if ((_recoil isNotEqualTo [0, 0]) && (isNumber (configFile >> "CfgRecoils" >> _recoil >> QGVAR(customShakeCoef))) then {
+    private _customShakeCoef = if ((_recoil isNotEqualTo [0, 0]) && (isNumber (configFile >> "CfgRecoils" >> _recoil >> QGVAR(customShakeCoef)))) then {
         getNumber (configFile >> "CfgRecoils" >> _recoil >> QGVAR(customShakeCoef))
     } else {
         1
     };
+
 
 
     _recoil = _recoil vectorMultiply _customShakeCoef;

--- a/docs/wiki/framework/recoil-framework.md
+++ b/docs/wiki/framework/recoil-framework.md
@@ -1,0 +1,32 @@
+---
+layout: wiki
+title: Recoil Framework
+description: Recoil overhaul.
+group: framework
+order: 5
+parent: wiki
+mod: ace
+version:
+  major: 3
+  minor: 3
+  patch: 0
+---
+
+
+## 1. Configs
+
+Custom recoil shake coef
+
+```cpp
+class CfgRecoils {
+    class myRecoil {
+        ace_recoil_customShakeCoef = 2; // default is 1
+    };
+};
+```
+
+## 2. Variables
+
+Secondary launchers have extra shake, this can be refined by setting
+
+`ace_recoil_extraLauncherShake = 10;` // default is 25


### PR DESCRIPTION
**When merged this pull request will:**
- title
- ace_recoil_customShakeCoef in CfgRecoils
- would like feedback on whether it's better to do per-weapon/muzzle or per-recoil as well as code in general

Some guns have a TON of shake if they have a ton of kickBack, so it'd be nice to be able to manually tune it down on import. (I specifically need this because of a launcher gun thing, but the idea is applicable to rifles with large amounts of kickBack in the recoil)

