### PR TITLE
interact_menu - Add "removeActionFromZeus" function

### DIFF
--- a/addons/interact_menu/XEH_PREP.hpp
+++ b/addons/interact_menu/XEH_PREP.hpp
@@ -18,6 +18,7 @@ PREP(keyDown);
 PREP(keyUp);
 PREP(removeActionFromClass);
 PREP(removeActionFromObject);
+PREP(removeActionFromZeus);
 PREP(render);
 PREP(renderActionPoints);
 PREP(renderBaseMenu);

--- a/addons/interact_menu/functions/fnc_removeActionFromZeus.sqf
+++ b/addons/interact_menu/functions/fnc_removeActionFromZeus.sqf
@@ -1,0 +1,53 @@
+#include "..\script_component.hpp"
+/*
+ * Author: Nomas / Redwan S.
+ * Removes an action from Zeus
+ *
+ * Arguments:
+ * 0: Full path of the action to remove <ARRAY>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [["ACE_ZeusActions", "MyZeusAction"]] call ace_interact_menu_fnc_removeActionFromZeus;
+ *
+ * Public: No
+ */
+
+if (!hasInterface) exitWith {};
+if (!params [["_fullPath", [], [[]]]]) exitWith {ERROR("Bad Params"); []};
+if ((_fullPath param [0, ""]) != "ACE_ZeusActions") exitWith {ERROR_1("Bad path %1 - should have ACE_ZeusActions as base",_fullPath); []};
+TRACE_1("removeActionFromZeus",_fullPath);
+
+private _res = _fullPath call FUNC(splitPath);
+_res params ["_parentPath", "_actionName"];
+
+private _currentPath = GVAR(ZeusActions);
+private _pathValid = false;
+{
+    private _targetParent = _x;
+    _pathValid = false;
+    {
+        _x params ["_xAction", "_xSubActions"];
+        if ((_xAction select 0) == _targetParent) exitWith {
+            _pathValid = true;
+            _currentPath = _xSubActions;
+        };
+    } forEach _currentPath;
+} forEach _parentPath;
+
+if (!_pathValid) exitWith {ERROR_1("Bad path %1",_parentPath); []};
+
+private _found = false;
+{
+    if (((_x select 0) select 0) == _actionName) exitWith {
+        TRACE_2("Deleting Zeus Action",_forEachIndex,_x);
+        _found = true;
+        _currentPath deleteAt _forEachIndex;
+    };
+} forEach _currentPath;
+
+if (!_found) then {
+    WARNING("Failed to find action to delete");
+}

--- a/addons/interact_menu/functions/fnc_removeActionFromZeus.sqf
+++ b/addons/interact_menu/functions/fnc_removeActionFromZeus.sqf
@@ -20,8 +20,7 @@ if (!params [["_fullPath", [], [[]]]]) exitWith {ERROR("Bad Params"); []};
 if ((_fullPath param [0, ""]) != "ACE_ZeusActions") exitWith {ERROR_1("Bad path %1 - should have ACE_ZeusActions as base",_fullPath); []};
 TRACE_1("removeActionFromZeus",_fullPath);
 
-private _res = _fullPath call FUNC(splitPath);
-_res params ["_parentPath", "_actionName"];
+_fullPath call FUNC(splitPath) params ["_parentPath", "_actionName"];
 
 private _currentPath = GVAR(ZeusActions);
 private _pathValid = false;


### PR DESCRIPTION
**When merged this pull request will:**
- This merge will add a function to remove actions from Zeus as currently you can only add actions unlike class or object actions.
- I defined the new function `removeActionFromZeus` in `XEH_PREP.hpp``.
- I created the file for `removeActionFromZeus`as `fnc_removeActionFromZeus.sqf`` which contains the code to remove action.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.