### PR TITLE
Sandbag - Fix floating sandbags when building

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -227,6 +227,7 @@ if (isServer) then {
 [QGVAR(removeMagazinesTurret), {(_this select 0) removeMagazinesTurret [_this select 1, _this select 2]}] call CBA_fnc_addEventHandler;
 [QGVAR(setMagazineTurretAmmo), {(_this select 0) setMagazineTurretAmmo [_this select 1, _this select 2, _this select 3]}] call CBA_fnc_addEventHandler;
 [QGVAR(triggerAmmo), {triggerAmmo _this}] call CBA_fnc_addEventHandler;
+[QGVAR(awake), {(_this select 0) awake (_this select 1)}] call CBA_fnc_addEventHandler;
 
 [QGVAR(setVanillaHitPointDamage), {
     params ["_object", "_hitPointAnddamage"];

--- a/addons/sandbag/XEH_postInit.sqf
+++ b/addons/sandbag/XEH_postInit.sqf
@@ -72,7 +72,7 @@ if (["ace_dragging"] call EFUNC(common,isModLoaded)) then {
         // Force PhysX update
         {
             [QEGVAR(common,awake), [_x, true]] call CBA_fnc_globalEvent;
-        } forEach ((_target nearObjects ["ACE_SandbagObject", 5]) - [_target]);
+        } forEach ((_target nearObjects ["ACE_SandbagObject", 1.5]) - [_target]);
     }] call CBA_fnc_addEventHandler;
 
     // When carrying stops, update surrounding sandbags
@@ -84,6 +84,6 @@ if (["ace_dragging"] call EFUNC(common,isModLoaded)) then {
         // Force PhysX update
         {
             [QEGVAR(common,awake), [_x, true]] call CBA_fnc_globalEvent;
-        } forEach ((_target nearObjects ["ACE_SandbagObject", 5]) - [_target]);
+        } forEach ((_target nearObjects ["ACE_SandbagObject", 1.5]) - [_target]);
     }] call CBA_fnc_addEventHandler;
 };

--- a/addons/sandbag/functions/fnc_pickup.sqf
+++ b/addons/sandbag/functions/fnc_pickup.sqf
@@ -30,7 +30,7 @@ _unit setVariable [QGVAR(isUsingSandbag), true];
     // If another unit picked up the sandbag or otherwise sandbag no longer present, exit
     if (!alive _unit || {!alive _sandbag}) exitWith {};
 
-    private _nearSandbags = (_sandbag nearObjects ["ACE_SandbagObject", 5]) - [_sandbag];
+    private _nearSandbags = (_sandbag nearObjects ["ACE_SandbagObject", 1.5]) - [_sandbag];
 
     deleteVehicle _sandbag;
 


### PR DESCRIPTION
**When merged this pull request will:**
- Forgot to add the necessary EH in common (https://github.com/acemod/ACE3/pull/11278#discussion_r3254851876).
  The idea is to update the physics of other sandbags in the vicinity, so that they e.g. fall down if a sandbag below was removed. The sandbags update other sandbags when they are carried and when they are picked up.
  
### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
