### PR TITLE
Arsenal - Fix non-matching faces from showing in Arsenal

### DIFF
--- a/addons/arsenal/functions/fnc_fillLeftPanel.sqf
+++ b/addons/arsenal/functions/fnc_fillLeftPanel.sqf
@@ -88,9 +88,15 @@ private _selectedItem = if (_idxVirt != -1) then { // Items
         case IDC_buttonFace: {
             private _lbAdd = -1; // micro-optimization
             // Faces need to be added like this because their config path is
-            // configFile >> "CfgFaces" >> face category >> className
+            // configFile >> "CfgFaces" >> face type >> className
+            private _unitFaceType = getText (configOf GVAR(center) >> "faceType");
             {
-                _y params ["_displayName", "_modPicture"];
+                _y params ["_displayName", "_modPicture", "_faceType"];
+                if (_unitFaceType != _faceType) then {
+                    TRACE_3("Hid face that doesn't match faceType",_x,_unitFaceType,_faceType);
+                    continue
+                };
+
                 _lbAdd = _ctrlPanel lbAdd _displayName;
                 _ctrlPanel lbSetData [_lbAdd, _x];
                 _ctrlPanel lbSetTooltip [_lbAdd, format ["%1\n%2", _displayName, _x]];


### PR DESCRIPTION
**When merged this pull request will:**
- Hide faces that don't match the unit's `faceType`
  - Logs a message in debug mode, `9:07:30 [ACE] (arsenal) TRACE: 16209 Hid face that doesn't match faceType: _x=faceClassName, _unitFaceType=Man_A3, _faceType=customFaceType z\ace\addons\arsenal\functions\fnc_fillLeftPanel.sqf:96`
  - Fixes issues with heads for custom skeletons showing when editing a unit

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
