### PR TITLE
Common - Fix object tilt on horizontal surfaces on sloped terrain

### DIFF
--- a/addons/common/functions/fnc_fixPosition.sqf
+++ b/addons/common/functions/fnc_fixPosition.sqf
@@ -10,7 +10,7 @@
  * None
  *
  * Example:
- * bob call ace_common_fnc_fixPosition
+ * cursorObject call ace_common_fnc_fixPosition
  *
  * Public: No
  */
@@ -21,15 +21,17 @@ if (!local _this) exitWith {};
 // Objects with disabled simulation and objects with simulation type "house" don't have gravity/physics, so make sure they are not floating
 private _hasGravity = simulationEnabled _this && {getText (configOf _this >> "simulation") != "house"};
 
-if (!_hasGravity) then {
-    private _positionASL = getPosASL _this;
-    // find height of top surface under object
-    private _surfaces = lineIntersectsSurfaces [_positionASL, ATLToASL [_positionASL select 0, _positionASL select 1, -1], _this];
-    if (_surfaces isEqualTo []) exitWith {};
-    private _surfaceHeight = _surfaces select 0 select 0 select 2;
-    TRACE_2("house",_this,_surfaceHeight);
-    if (_positionASL select 2 > _surfaceHeight + 0.1) then {
-        _this setPosASL [_positionASL select 0, _positionASL select 1, _surfaceHeight];
+private _positionASL = getPosASL _this;
+_positionASL params ["_posX", "_posY", "_posZASL"];
+// find top surface under object
+private _surfaces = lineIntersectsSurfaces [_positionASL, ATLToASL [_posX, _posY, -1], _this];
+
+TRACE_3("fixPosition",_this,_hasGravity,_surfaces);
+
+if (!_hasGravity && {_surfaces isNotEqualTo []}) then {
+    private _surfaceHeightASL = _surfaces select 0 select 0 select 2;
+    if (_posZASL > _surfaceHeightASL + 0.1) then {
+        _this setPosASL [_posX, _posY, _surfaceHeightASL];
     };
 };
 
@@ -41,8 +43,19 @@ if (_position select 2 < -0.1) then {
     _this setPosATL _position;
 };
 
-// Adjust position to sloped terrain, if placed on ground
+// Adjust position to sloped surface, if placed on ground
 // Object without gravity/physics may have negative height when placed on slope, but those objects are definitely on the ground
 if (!_hasGravity || {getPosATL _this select 2 == _position select 2}) then {
-    _this setVectorUp surfaceNormal _position;
+    private _normal = if (_surfaces isEqualTo []) then {
+        surfaceNormal _position
+    } else {
+        private _surfaceNormal = _surfaces select 0 select 1;
+        // on flipped surfaces fallback to terrain
+        if (_surfaceNormal select 2 > 0) then {
+            _surfaceNormal
+        } else {
+            surfaceNormal _position
+        }
+    };
+    _this setVectorUp _normal;
 };


### PR DESCRIPTION
**When merged this pull request will:**
- fix object tilt on horizontal surfaces on sloped terrain e.g. when carry-drop or unload cargo;
- improve naming, debug trace, example.

Currently the object's orientation is determined only by the terrain slope; the surface beneath the object is ignored.

<img width="502" height="352" alt="50" src="https://github.com/user-attachments/assets/1b354362-0fde-44e9-a292-063e4c96c572" />
