### PR TITLE
Arsenal - Add magazine classname searching & improve left hand search

### DIFF
--- a/addons/arsenal/functions/fnc_handleSearchbar.sqf
+++ b/addons/arsenal/functions/fnc_handleSearchbar.sqf
@@ -151,6 +151,7 @@ if ((ctrlIDC _control) == IDC_rightSearchbar) then {
     private _currentDisplayName = "";
     private _currentClassname = "";
 
+    private _isMagazine = isClass (configFile >> "CfgMagazines" >> _searchString); // Check if search term is a magazine for magazine lookups. Direct match is fine as user will ctrl+c the classname
     // Go through all items in panel and see if they need to be deleted or not
     for "_lbIndex" from (lbSize _leftPanelCtrl) - 1 to 0 step -1 do {
         _currentDisplayName = _leftPanelCtrl lbText _lbIndex;
@@ -159,7 +160,7 @@ if ((ctrlIDC _control) == IDC_rightSearchbar) then {
         if (_currentDisplayName isEqualTo format [" <%1>", localize "str_empty"]) then {continue};
 
         // Remove item in panel if it doesn't match search, skip otherwise
-        if ((_currentDisplayName == "") || {!(_currentDisplayName regexMatch _searchPattern) && {!(_currentClassname regexMatch _searchPattern) && {!(isClass (configFile >> "CfgMagazines" >> _searchString) && {_searchString in (compatibleMagazines _currentClassname)})}}}) then {
+        if ((_currentDisplayName == "") || {!(_currentDisplayName regexMatch _searchPattern) && {!(_currentClassname regexMatch _searchPattern) && {!_isMagazine && {_searchString in (compatibleMagazines _currentClassname)}}}}) then {
             _leftPanelCtrl lbDelete _lbIndex;
         };
     };

--- a/addons/arsenal/functions/fnc_handleSearchbar.sqf
+++ b/addons/arsenal/functions/fnc_handleSearchbar.sqf
@@ -156,8 +156,10 @@ if ((ctrlIDC _control) == IDC_rightSearchbar) then {
         _currentDisplayName = _leftPanelCtrl lbText _lbIndex;
         _currentClassname = _leftPanelCtrl lbData _lbIndex;
 
+        if (_currentDisplayName isEqualTo format [" <%1>", localize "str_empty"]) then {continue};
+
         // Remove item in panel if it doesn't match search, skip otherwise
-        if ((_currentDisplayName == "") || {!(_currentDisplayName regexMatch _searchPattern) && {!(_currentClassname regexMatch _searchPattern)}}) then {
+        if ((_currentDisplayName == "") || {!(_currentDisplayName regexMatch _searchPattern) && {!(_currentClassname regexMatch _searchPattern) && {!(isClass (configFile >> "CfgMagazines" >> _searchString) && {_searchString in (compatibleMagazines _currentClassname)})}}}) then {
             _leftPanelCtrl lbDelete _lbIndex;
         };
     };

--- a/addons/arsenal/functions/fnc_handleSearchbar.sqf
+++ b/addons/arsenal/functions/fnc_handleSearchbar.sqf
@@ -61,7 +61,7 @@ if ((ctrlIDC _control) == IDC_rightSearchbar) then {
             _currentClassname = _rightPanelCtrl lbData _lbIndex;
 
             // Remove item in panel if it doesn't match search, skip otherwise
-            if ((_currentDisplayName == "") || {!(_currentDisplayName regexMatch _searchPattern) && {!(_currentClassname regexMatch _searchPattern) && {!(GVAR(searchMagazines) && _searchString in (compatibleMagazines _currentClassname))}}}) then {
+            if ((_currentDisplayName == "") || {!(_currentDisplayName regexMatch _searchPattern) && {!(_currentClassname regexMatch _searchPattern)}}) then {
                 _rightPanelCtrl lbDelete _lbIndex;
             };
         };

--- a/addons/arsenal/functions/fnc_handleSearchbar.sqf
+++ b/addons/arsenal/functions/fnc_handleSearchbar.sqf
@@ -61,7 +61,7 @@ if ((ctrlIDC _control) == IDC_rightSearchbar) then {
             _currentClassname = _rightPanelCtrl lbData _lbIndex;
 
             // Remove item in panel if it doesn't match search, skip otherwise
-            if ((_currentDisplayName == "") || {!(_currentDisplayName regexMatch _searchPattern) && {!(_currentClassname regexMatch _searchPattern)}}) then {
+            if ((_currentDisplayName == "") || {!(_currentDisplayName regexMatch _searchPattern) && {!(_currentClassname regexMatch _searchPattern) && {!(GVAR(searchMagazines) && _searchString in (compatibleMagazines _currentClassname))}}}) then {
                 _rightPanelCtrl lbDelete _lbIndex;
             };
         };


### PR DESCRIPTION
**When merged this pull request will:**
- Allow searching via magazines
  - Only exact matches (given I figure it's getting ctrl+c'd anyway)
  - Will NOT try to look through compatibleMagazines if the search term is not an exact match for a magazine classname.
- Make `<Empty>` always show even through searches.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
