### PR TITLE
MILR - Add Popup hint for range

### DIFF
--- a/addons/milr/XEH_preInit.sqf
+++ b/addons/milr/XEH_preInit.sqf
@@ -6,4 +6,6 @@ PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
 PREP_RECOMPILE_END;
 
+#include "initSettings.inc.sqf"
+
 ADDON = true;

--- a/addons/milr/functions/fnc_keyPress.sqf
+++ b/addons/milr/functions/fnc_keyPress.sqf
@@ -32,6 +32,9 @@ switch (_func) do {
             private _range = if (_holdTime < 5) then { [_player] call FUNC(getRange) } else { 0 };
             TRACE_1("Updating range",_range);
             GVAR(data) set ["range", _range];
+            if (_range > 5) then {
+                [[LLSTRING(milrRangeDisplay), (round _range)], 1.5, _player, 8] call EFUNC(common,displayTextStructured);
+            };
             // systemChat format ["DEBUG: range: %1 meters", _range];
         };
     };

--- a/addons/milr/functions/fnc_keyPress.sqf
+++ b/addons/milr/functions/fnc_keyPress.sqf
@@ -32,8 +32,8 @@ switch (_func) do {
             private _range = if (_holdTime < 5) then { [_player] call FUNC(getRange) } else { 0 };
             TRACE_1("Updating range",_range);
             GVAR(data) set ["range", _range];
-            if (_range > 5) then {
-                [[LLSTRING(milrRangeDisplay), (round _range)], 1.5, _player, 8] call EFUNC(common,displayTextStructured);
+            if (_range > 5 && {GVAR(showRangeHint) == 1}) then {
+                [[format ["%1 %2 %3", LLSTRING(milrRangeDisplay), (round _range), LLSTRING(meter)]], 1.5, _player, 8] call EFUNC(common,displayTextStructured);
             };
             // systemChat format ["DEBUG: range: %1 meters", _range];
         };

--- a/addons/milr/initSettings.inc.sqf
+++ b/addons/milr/initSettings.inc.sqf
@@ -1,0 +1,8 @@
+[
+    QGVAR(showRangeHint),
+    "LIST",
+    [LSTRING(showRangeHint)],
+    [ELSTRING(common,ACEKeybindCategoryWeapons), QUOTE(COMPONENT_BEAUTIFIED)],
+    [[0, 1], [ELSTRING(common,Disabled), ELSTRING(common,Enabled)], 1],
+    0 // user setting
+] call CBA_fnc_addSetting;

--- a/addons/milr/stringtable.xml
+++ b/addons/milr/stringtable.xml
@@ -7,5 +7,8 @@
             <Japanese>赤外線レーザー照準器と距離計</Japanese>
             <Russian>ИК-лазерная указка и дальномер</Russian>
         </Key>
+        <Key ID="STR_ACE_MILR_milrRangeDisplay">
+            <English>Range: %1 Meters</English>
+        </Key>
     </Package>
 </Project>

--- a/addons/milr/stringtable.xml
+++ b/addons/milr/stringtable.xml
@@ -8,7 +8,6 @@
             <Russian>ИК-лазерная указка и дальномер</Russian>
         </Key>
         <Key ID="STR_ACE_MILR_meter">
-            <Original>m</Original>
             <English>m</English>
             <Czech>m</Czech>
             <French>m</French>

--- a/addons/milr/stringtable.xml
+++ b/addons/milr/stringtable.xml
@@ -7,8 +7,42 @@
             <Japanese>赤外線レーザー照準器と距離計</Japanese>
             <Russian>ИК-лазерная указка и дальномер</Russian>
         </Key>
+        <Key ID="STR_ACE_MILR_meter">
+            <Original>m</Original>
+            <English>m</English>
+            <Czech>m</Czech>
+            <French>m</French>
+            <Spanish>m</Spanish>
+            <Italian>m</Italian>
+            <Polish>m</Polish>
+            <Portuguese>m</Portuguese>
+            <Russian>м</Russian>
+            <German>m</German>
+            <Korean>m</Korean>
+            <Japanese>m</Japanese>
+            <Chinese>公尺</Chinese>
+            <Chinesesimp>米</Chinesesimp>
+            <Turkish>m</Turkish>
+        </Key>
         <Key ID="STR_ACE_MILR_milrRangeDisplay">
-            <English>Range: %1 Meters</English>
+            <English>Range:</English>
+            <Czech>Vzdálenost:</Czech>
+            <French>Distance :</French>
+            <Spanish>Distancia:</Spanish>
+            <Italian>Distanza:</Italian>
+            <Polish>Dystans:</Polish>
+            <Portuguese>Distância:</Portuguese>
+            <Russian>Дистанция:</Russian>
+            <German>Distanz:</German>
+            <Korean>거리:</Korean>
+            <Japanese>距離:</Japanese>
+            <Chinese>範圍:</Chinese>
+            <Chinesesimp>范围：</Chinesesimp>
+            <Hungarian>Távolság:</Hungarian>
+            <Ukrainian>Дистанція:</Ukrainian>
+        </Key>
+        <Key ID="STR_ACE_MILR_showRangeHint">
+            <English>Show range hint</English>
         </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Adds a small pop-up when ranging with a MILR. for weapons that have a right-sided laser module

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
