### PR TITLE
Explosives - Change deadman explosives location

### DIFF
--- a/addons/explosives/functions/fnc_onIncapacitated.sqf
+++ b/addons/explosives/functions/fnc_onIncapacitated.sqf
@@ -55,7 +55,7 @@ if (isText (_magazineTrigger >> "ammo")) then {
 };
 
 private _explosive = _ammo createVehicle [0, 0, 0];
-_explosive setPosASL (getPosASL _unit);
+_explosive attachTo [_unit, [0, 0.15, 0.15], "Pelvis"];
 
 // Explode, ignoring range, with a 0.5 second delay
 [_unit, -1, [_explosive, 0.5], "ACE_DeadManSwitch"] call FUNC(detonateExplosive);


### PR DESCRIPTION
**When merged this pull request will:**
- Explosives tied to the deadman switch will now be attached to the unit, so that in case the unit is going very fast the explosive will follow the unit until it detonates. I've never observed this being an issue, but I figured it's best to address it now.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
