### PR TITLE
ArtilleryTables - Add Ships to table calculation

### DIFF
--- a/addons/artillerytables/functions/fnc_interactMenuOpened.sqf
+++ b/addons/artillerytables/functions/fnc_interactMenuOpened.sqf
@@ -104,4 +104,4 @@ TRACE_2("searching for new vehicles",_vehicleAdded,_rangeTablesShown);
             ace_player setVariable [QGVAR(rangeTablesShown), _rangeTablesShown];
         };
     };
-} forEach (nearestObjects [ace_player, ["LandVehicle"], 25]);
+} forEach (nearestObjects [ace_player, ["LandVehicle", "Ship"], 25]);


### PR DESCRIPTION
**When merged this pull request will:**
- Allow boats/ships to be considered artillery pieces to fill the artillery table menu

Probably should also write a "why" for this change.

Allows custom ship vehicles, which have an artillery weapon to use the artillery table as well instead of requiring the boring vanilla artillery computer. I am not talking about the vanilla boat guns, this is to add support for custom ships which have an MLRS or similar configured as a gun.