### PR TITLE
Vehicles - Make cruise control disable when vehicle stops

### DIFF
--- a/addons/vehicles/XEH_PREP.hpp
+++ b/addons/vehicles/XEH_PREP.hpp
@@ -1,5 +1,5 @@
 PREP(autoThrottle);
-PREP(speedLimiter);
+PREP(speedControl);
 PREP(startEngine);
 PREP(setVehicleStartDelay);
 PREP(toggleSpeedControl);

--- a/addons/vehicles/XEH_postInit.sqf
+++ b/addons/vehicles/XEH_postInit.sqf
@@ -2,7 +2,7 @@
 #include "script_component.hpp"
 
 if (!hasInterface) exitWith {};
-GVAR(isSpeedLimiter) = false;
+GVAR(isSpeedControlActive) = false;
 
 // Add keybinds
 ["ACE3 Vehicles", QGVAR(speedLimiter), localize LSTRING(SpeedLimiter), {
@@ -14,7 +14,7 @@ GVAR(isSpeedLimiter) = false;
 }, {false}, [DIK_INSERT, [false, false, false]], false] call CBA_fnc_addKeybind;
 
 ["ACE3 Vehicles", QGVAR(scrollUp), localize LSTRING(IncreaseSpeedLimit), {
-    if (GVAR(isSpeedLimiter)) then {
+    if (GVAR(isSpeedControlActive)) then {
         GVAR(speedLimit) = round (GVAR(speedLimit) + GVAR(speedLimiterStep)) max (5 max GVAR(speedLimiterStep));
         GVAR(speedLimit) = 5 max GVAR(speedLimiterStep) * floor (GVAR(speedLimit) / GVAR(speedLimiterStep));
         [["%1: %2", LSTRING(SpeedLimit), GVAR(speedLimit)]] call EFUNC(common,displayTextStructured);
@@ -26,7 +26,7 @@ GVAR(isSpeedLimiter) = false;
 }, {false}, [MOUSE_SCROLL_UP, [false, true, false]], false] call CBA_fnc_addKeybind; // Ctrl + Mouse Wheel Scroll Up
 
 ["ACE3 Vehicles", QGVAR(scrollDown), localize LSTRING(DecreaseSpeedLimit), {
-    if (GVAR(isSpeedLimiter)) then {
+    if (GVAR(isSpeedControlActive)) then {
         GVAR(speedLimit) = round (GVAR(speedLimit) - GVAR(speedLimiterStep)) max (5 max GVAR(speedLimiterStep));
         GVAR(speedLimit) = 5 max GVAR(speedLimiterStep) * ceil (GVAR(speedLimit) / GVAR(speedLimiterStep));
         [["%1: %2", LSTRING(SpeedLimit), GVAR(speedLimit)]] call EFUNC(common,displayTextStructured);

--- a/addons/vehicles/functions/fnc_autoThrottle.sqf
+++ b/addons/vehicles/functions/fnc_autoThrottle.sqf
@@ -25,15 +25,15 @@
 
 params ["_driver", "_vehicle", ["_preserveSpeedLimit", false]];
 
-if (GVAR(isSpeedLimiter)) exitWith {
+if (GVAR(isSpeedControlActive)) exitWith {
     [localize LSTRING(Off)] call EFUNC(common,displayTextStructured);
     playSound "ACE_Sound_Click";
-    GVAR(isSpeedLimiter) = false;
+    GVAR(isSpeedControlActive) = false;
 };
 
 [localize LSTRING(On)] call EFUNC(common,displayTextStructured);
 playSound "ACE_Sound_Click";
-GVAR(isSpeedLimiter) = true;
+GVAR(isSpeedControlActive) = true;
 GVAR(isCruiseControl) = true; // enables SET/RESUME
 
 private _speedLimitMS = ((velocityModelSpace _vehicle) select 1) max (5 / 3.6);
@@ -71,11 +71,11 @@ private _airData = [_thrustLogFactor, _maxSpeed, _acceleration, _thrustCoefs, _t
     private _role = _driver call EFUNC(common,getUavControlPosition);
     if (GVAR(isUAV)) then {
         if (_role != "DRIVER") then {
-            GVAR(isSpeedLimiter) = false;
+            GVAR(isSpeedControlActive) = false;
         };
     } else {
         if (_driver != currentPilot _vehicle || {_role != ""}) then {
-            GVAR(isSpeedLimiter) = false;
+            GVAR(isSpeedControlActive) = false;
         };
     };
 
@@ -92,14 +92,14 @@ private _airData = [_thrustLogFactor, _maxSpeed, _acceleration, _thrustCoefs, _t
         // ARMA will allow an increment of one throttle unit per frame, so if there is a difference between our known throttle value and actual throttle value, the player must of changed it
         [localize LSTRING(Off)] call EFUNC(common,displayTextStructured);
         playSound "ACE_Sound_Click";
-        GVAR(isSpeedLimiter) = false;
+        GVAR(isSpeedControlActive) = false;
     };
 
     if (call CBA_fnc_getActiveFeatureCamera != "") then {
-        GVAR(isSpeedLimiter) = false;
+        GVAR(isSpeedControlActive) = false;
     };
 
-    if (!GVAR(isSpeedLimiter)) exitWith {
+    if (!GVAR(isSpeedControlActive)) exitWith {
         [_idPFH] call CBA_fnc_removePerFrameHandler;
     };
 
@@ -127,9 +127,8 @@ private _airData = [_thrustLogFactor, _maxSpeed, _acceleration, _thrustCoefs, _t
 
     private _velocityCommand = [_pid, _velocity] call CBA_pid_fnc_update;
     private _throttle = 1 min (0 max (_currentThrottle + _velocityCommand / _availableAcceleration));
-    
+
     _vehicle setAirplaneThrottle _throttle;
     _args set [4, _throttle];
 
 }, 0, [_driver, _vehicle, _pid, _airData, -1]] call CBA_fnc_addPerFrameHandler;
-

--- a/addons/vehicles/functions/fnc_speedControl.sqf
+++ b/addons/vehicles/functions/fnc_speedControl.sqf
@@ -1,7 +1,7 @@
 #include "..\script_component.hpp"
 /*
  * Author: commy2
- * Toggle speed limiter for Driver in Vehicle.
+ * Toggle speed control for Driver in Vehicle.
  *
  * Arguments:
  * 0: Driver <OBJECT>
@@ -13,20 +13,20 @@
  * None
  *
  * Example:
- * [player, car, true] call ace_vehicles_fnc_speedLimiter
+ * [player, car, true] call ace_vehicles_fnc_speedControl
  *
  * Public: No
  */
 
 params ["_driver", "_vehicle", ["_cruiseControl", false], ["_preserveSpeedLimit", false]];
 
-if (GVAR(isSpeedLimiter)) exitWith {
+if (GVAR(isSpeedControlActive)) exitWith {
     switch ([GVAR(isCruiseControl), _cruiseControl]) do {
         case [true, true]: {
             [localize LSTRING(OffCruise)] call EFUNC(common,displayTextStructured);
             playSound "ACE_Sound_Click";
             _vehicle setCruiseControl [0, false];
-            GVAR(isSpeedLimiter) = false;
+            GVAR(isSpeedControlActive) = false;
         };
         case [true, false]: {
             [localize LSTRING(On)] call EFUNC(common,displayTextStructured);
@@ -44,7 +44,7 @@ if (GVAR(isSpeedLimiter)) exitWith {
             [localize LSTRING(Off)] call EFUNC(common,displayTextStructured);
             playSound "ACE_Sound_Click";
             _vehicle setCruiseControl [0, false];
-            GVAR(isSpeedLimiter) = false;
+            GVAR(isSpeedControlActive) = false;
         };
     };
 };
@@ -56,7 +56,7 @@ if (_speedLimit != 0) exitWith { TRACE_1("speed limit set by external source",_s
     [LSTRING(On), LSTRING(OnCruise)] select _cruiseControl
 )] call EFUNC(common,displayTextStructured);
 playSound "ACE_Sound_Click";
-GVAR(isSpeedLimiter) = true;
+GVAR(isSpeedControlActive) = true;
 GVAR(isCruiseControl) = _cruiseControl;
 
 if (!_preserveSpeedLimit) then {
@@ -71,21 +71,27 @@ GVAR(speedLimitInit) = true;
     private _role = _driver call EFUNC(common,getUavControlPosition);
     if (GVAR(isUAV)) then {
         if (_role == "") then {
-            GVAR(isSpeedLimiter) = false;
+            GVAR(isSpeedControlActive) = false;
             TRACE_1("UAV controller changed, disabling speedlimit",_vehicle);
         };
     } else {
         if (_driver != driver _vehicle || {_role != ""}) then {
-            GVAR(isSpeedLimiter) = false;
+            GVAR(isSpeedControlActive) = false;
             TRACE_3("Vehicle driver changed, disabling speedlimit",_driver,driver _vehicle,_vehicle);
         };
     };
 
     if (call CBA_fnc_getActiveFeatureCamera != "") then {
-        GVAR(isSpeedLimiter) = false;
+        GVAR(isSpeedControlActive) = false;
     };
 
-    if (!GVAR(isSpeedLimiter)) exitWith {
+    if (GVAR(isCruiseControl) && {speed _vehicle < 1}) then { // handle vehicle flip/collision
+        GVAR(isSpeedControlActive) = false;
+        [localize LSTRING(OffCruise)] call EFUNC(common,displayTextStructured);
+        playSound "ACE_Sound_Click";
+    };
+
+    if (!GVAR(isSpeedControlActive)) exitWith {
         _vehicle setCruiseControl [0, false];
         [_idPFH] call CBA_fnc_removePerFrameHandler;
     };
@@ -93,7 +99,7 @@ GVAR(speedLimitInit) = true;
     getCruiseControl _vehicle params ["_currentSpeedLimit", "_cruiseControlActive"];
     if (GVAR(isCruiseControl) && {!GVAR(speedLimitInit) && {!_cruiseControlActive}}) exitWith {
         [_idPFH] call CBA_fnc_removePerFrameHandler;
-        GVAR(isSpeedLimiter) = false;
+        GVAR(isSpeedControlActive) = false;
         [localize LSTRING(OffCruise)] call EFUNC(common,displayTextStructured);
         playSound "ACE_Sound_Click";
     };

--- a/addons/vehicles/functions/fnc_toggleSpeedControl.sqf
+++ b/addons/vehicles/functions/fnc_toggleSpeedControl.sqf
@@ -41,7 +41,7 @@ if (_role != "") then {
 if (
     !_continue
     || {!(isEngineOn _vehicle)}
-    || {!GVAR(isSpeedLimiter) && _cruiseControl && {speed _vehicle < 1}} // don't enable CC when stop or move backward
+    || {!GVAR(isSpeedControlActive) && _cruiseControl && {speed _vehicle < 1}} // don't enable CC when stop or move backward
 ) exitWith {false};
 
 private _allowedVehicleClasses = ["Car", "Tank", "Ship"];
@@ -53,7 +53,7 @@ if (-1 == _allowedVehicleClasses findIf {_vehicle isKindOf _x}) exitWith {false}
 if (_vehicle isKindOf "Plane") then {
     [ACE_player, _vehicle, _preserveSpeedLimit] call FUNC(autoThrottle);
 } else {
-    [ACE_player, _vehicle, _cruiseControl, _preserveSpeedLimit] call FUNC(speedLimiter);
+    [ACE_player, _vehicle, _cruiseControl, _preserveSpeedLimit] call FUNC(speedControl);
 };
 
 true


### PR DESCRIPTION
**When merged this pull request will:**
- make cruise control disable when vehicle stops/flips/reverses (e.g. after collision);
- rename `fnc_speedLimiter` to `fnc_speedControl`;
- rename `isSpeedLimiter` variable to `isSpeedControlActive`.
