### PR TITLE
Various - Reorganize setting categories

### DIFF
--- a/addons/ai/initSettings.inc.sqf
+++ b/addons/ai/initSettings.inc.sqf
@@ -1,4 +1,4 @@
-private _category = format ["ACE %1", LLSTRING(DisplayName)];
+private _category = [LELSTRING(common,ACEKeybindCategoryEquipment), LLSTRING(DisplayName)];
 
 [
     QGVAR(assignNVG), "CHECKBOX",

--- a/addons/casings/initSettings.inc.sqf
+++ b/addons/casings/initSettings.inc.sqf
@@ -1,7 +1,9 @@
+private _category = [ELSTRING(common,ACEKeybindCategoryWeapons), LSTRING(Settings_DisplayName)];
+
 [
     QGVAR(enabled), "CHECKBOX",
     [LSTRING(displayName), LSTRING(description)],
-    LSTRING(Settings_DisplayName),
+    _category,
     true,
     false,
     {},
@@ -11,7 +13,7 @@
 [
     QGVAR(maxCasings), "SLIDER",
     [LSTRING(maxCasings_displayName), LSTRING(maxCasings_description)],
-    LSTRING(Settings_DisplayName),
+    _category,
     [100, 500, 250, -1],
     false
 ] call CBA_fnc_addSetting;

--- a/addons/casings/stringtable.xml
+++ b/addons/casings/stringtable.xml
@@ -2,18 +2,18 @@
 <Project name="ACE">
     <Package name="Casings">
         <Key ID="STR_ACE_Casings_Settings_DisplayName">
-            <English>ACE Casings</English>
-            <French>ACE Douilles</French>
-            <Spanish>ACE Casquillos</Spanish>
-            <Italian>ACE Bossoli</Italian>
-            <Polish>ACE Łuski</Polish>
-            <Portuguese>ACE Cartuchos</Portuguese>
-            <Russian>ACE Гильзы</Russian>
-            <German>ACE Patronenhülsen</German>
-            <Korean>ACE 탄피</Korean>
-            <Japanese>ACE 薬莢</Japanese>
-            <Chinesesimp>ACE 弹壳</Chinesesimp>
-            <Ukrainian>ACE Гільзи</Ukrainian>
+            <English>Casings</English>
+            <French>Douilles</French>
+            <Spanish>Casquillos</Spanish>
+            <Italian>Bossoli</Italian>
+            <Polish>Łuski</Polish>
+            <Portuguese>Cartuchos</Portuguese>
+            <Russian>Гильзы</Russian>
+            <German>Patronenhülsen</German>
+            <Korean>탄피</Korean>
+            <Japanese>薬莢</Japanese>
+            <Chinesesimp>弹壳</Chinesesimp>
+            <Ukrainian>Гільзи</Ukrainian>
         </Key>
         <Key ID="STR_ACE_Casings_description">
             <English>Enable persistent casings (POTENTIAL performance impact on old/weak systems)</English>

--- a/addons/common/initSettings.inc.sqf
+++ b/addons/common/initSettings.inc.sqf
@@ -1,6 +1,8 @@
 private _category = format ["ACE %1", LLSTRING(DisplayName)];
 private _categoryColors = [_category, LSTRING(subcategory_colors)];
-private _categorySway = [_category, LSTRING(subcategory_sway)];
+private _categoryEquipment = LLSTRING(ACEKeybindCategoryEquipment);
+private _categoryWeapons = LSTRING(ACEKeybindCategoryWeapons);
+private _categorySway = [_categoryWeapons, LSTRING(subcategory_sway)];
 
 [
     QGVAR(checkPBOsAction),
@@ -78,7 +80,7 @@ private _categorySway = [_category, LSTRING(subcategory_sway)];
     QGVAR(persistentLaserEnabled),
     "CHECKBOX",
     [LSTRING(SettingPersistentLaserName), LSTRING(SettingPersistentLaserDesc)],
-    LSTRING(ACEKeybindCategoryWeapons),
+    _categoryWeapons,
     false,
     false,
     LINKFUNC(switchPersistentLaser)
@@ -115,7 +117,7 @@ private _categorySway = [_category, LSTRING(subcategory_sway)];
     QGVAR(magneticDeclination),
     "CHECKBOX",
     [LSTRING(magneticDeclination), LSTRING(magneticDeclinationooltip)],
-    _category,
+    _categoryEquipment,
     false,
     1,
     {call FUNC(getMagneticBearingOffset)}

--- a/addons/flags/initSettings.inc.sqf
+++ b/addons/flags/initSettings.inc.sqf
@@ -1,4 +1,4 @@
-private _category = [LELSTRING(common,categoryUncategorized), LLSTRING(SettingCategory)];
+private _category = [LELSTRING(common,ACEKeybindCategoryEquipment), LLSTRING(SettingCategory)];
 
 [
     QGVAR(enablePlacing),

--- a/addons/goggles/initSettings.inc.sqf
+++ b/addons/goggles/initSettings.inc.sqf
@@ -1,7 +1,9 @@
+private _category = [LELSTRING(common,ACEKeybindCategoryEquipment), LLSTRING(SettingsName)];
+
 [
     QGVAR(effects), "LIST",
     LSTRING(effects_displayName),
-    localize LSTRING(SettingsName),
+    _category,
     [[0, 1, 2, 3], [ELSTRING(common,Disabled), LSTRING(effects_tintOnly), LSTRING(enabled_tintAndEffects), LSTRING(effects_effectsOnly)], 2],
     0,
     {[QGVAR(effects), _this] call EFUNC(common,cbaSettings_settingChanged)},
@@ -11,7 +13,7 @@
 [
     QGVAR(showInThirdPerson), "CHECKBOX",
     LSTRING(ShowInThirdPerson),
-    localize LSTRING(SettingsName),
+    _category,
     false,
     0
 ] call CBA_fnc_addSetting;
@@ -19,7 +21,7 @@
 [
     QGVAR(showClearGlasses), "CHECKBOX",
     [LSTRING(SettingShowClearGlasses), LELSTRING(common,showActionInSelfInteraction)],
-    localize LSTRING(SettingsName),
+    _category,
     false, // default value
     0 // isGlobal
 ] call CBA_fnc_addSetting;
@@ -27,7 +29,7 @@
 [
     QGVAR(drawOverlay), "CHECKBOX",
     LSTRING(SettingDrawOverlay),
-    localize LSTRING(SettingsName),
+    _category,
     true,
     0
 ] call CBA_fnc_addSetting;

--- a/addons/goggles/stringtable.xml
+++ b/addons/goggles/stringtable.xml
@@ -47,21 +47,21 @@
             <Ukrainian>Показувати дію Протерти окуляри</Ukrainian>
         </Key>
         <Key ID="STR_ACE_Goggles_SettingsName">
-            <English>ACE Goggles</English>
-            <Czech>ACE Brýle</Czech>
-            <French>ACE Lunettes</French>
-            <Spanish>[ACE] Gafas</Spanish>
-            <Italian>ACE Occhiali</Italian>
-            <Polish>ACE Gogle</Polish>
-            <Portuguese>ACE Óculos</Portuguese>
-            <Russian>ACE Очки</Russian>
-            <German>ACE Schutzbrille</German>
-            <Korean>ACE 고글</Korean>
-            <Japanese>ACE ゴーグル</Japanese>
-            <Chinese>ACE 護目鏡</Chinese>
-            <Chinesesimp>ACE 护目镜</Chinesesimp>
-            <Turkish>ACE Gözlük</Turkish>
-            <Ukrainian>ACE Окуляри</Ukrainian>
+            <English>Goggles</English>
+            <Czech>Brýle</Czech>
+            <French>Lunettes</French>
+            <Spanish>Gafas</Spanish>
+            <Italian>Occhiali</Italian>
+            <Polish>Gogle</Polish>
+            <Portuguese>Óculos</Portuguese>
+            <Russian>Очки</Russian>
+            <German>Schutzbrille</German>
+            <Korean>고글</Korean>
+            <Japanese>ゴーグル</Japanese>
+            <Chinese>護目鏡</Chinese>
+            <Chinesesimp>护目镜</Chinesesimp>
+            <Turkish>Gözlük</Turkish>
+            <Ukrainian>Окуляри</Ukrainian>
         </Key>
         <Key ID="STR_ACE_Goggles_ShowInThirdPerson">
             <English>Show Goggle Effects in Third Person</English>

--- a/addons/grenades/initSettings.inc.sqf
+++ b/addons/grenades/initSettings.inc.sqf
@@ -2,7 +2,7 @@
     QGVAR(convertExplosives),
     "CHECKBOX",
     [LSTRING(convertExplosives_DisplayName), LSTRING(convertExplosives_Description)],
-    LSTRING(Settings_DisplayName),
+    [ELSTRING(common,ACEKeybindCategoryWeapons), LSTRING(Settings_DisplayName)],
     true,
     1,
     {[QGVAR(convertExplosives), _this] call EFUNC(common,cbaSettings_settingChanged)},

--- a/addons/grenades/stringtable.xml
+++ b/addons/grenades/stringtable.xml
@@ -625,21 +625,21 @@
             <Ukrainian>Ранець із вибухівкою (метальний)</Ukrainian>
         </Key>
         <Key ID="STR_ACE_Grenades_Settings_DisplayName">
-            <English>ACE Grenades</English>
-            <Czech>ACE Granáty</Czech>
-            <French>ACE Grenades</French>
-            <Spanish>ACE Granadas</Spanish>
-            <Italian>ACE Granate</Italian>
-            <Polish>ACE Granaty</Polish>
-            <Portuguese>ACE Granadas</Portuguese>
-            <Russian>ACE Гранаты</Russian>
-            <German>ACE Granaten</German>
-            <Korean>ACE 수류탄</Korean>
-            <Japanese>ACE 手榴弾</Japanese>
-            <Chinese>ACE 手榴彈</Chinese>
-            <Chinesesimp>ACE 手榴弹</Chinesesimp>
-            <Turkish>ACE Bombalar</Turkish>
-            <Ukrainian>ACE Гранати</Ukrainian>
+            <English>Grenades</English>
+            <Czech>Granáty</Czech>
+            <French>Grenades</French>
+            <Spanish>Granadas</Spanish>
+            <Italian>Granate</Italian>
+            <Polish>Granaty</Polish>
+            <Portuguese>Granadas</Portuguese>
+            <Russian>Гранаты</Russian>
+            <German>Granaten</German>
+            <Korean>수류탄</Korean>
+            <Japanese>手榴弾</Japanese>
+            <Chinese>手榴彈</Chinese>
+            <Chinesesimp>手榴弹</Chinesesimp>
+            <Turkish>Bombalar</Turkish>
+            <Ukrainian>Гранати</Ukrainian>
         </Key>
         <Key ID="STR_ACE_Grenades_SwitchGrenadeMode">
             <English>Switch Grenade Mode</English>

--- a/addons/gunbag/initSettings.inc.sqf
+++ b/addons/gunbag/initSettings.inc.sqf
@@ -1,4 +1,4 @@
-private _category = [LELSTRING(common,categoryUncategorized), LLSTRING(DisplayName_Settings)];
+private _category = [LELSTRING(common,ACEKeybindCategoryEquipment), LLSTRING(DisplayName_Settings)];
 
 [
     QGVAR(swapGunbagEnabled), "CHECKBOX",

--- a/addons/inventory/initSettings.inc.sqf
+++ b/addons/inventory/initSettings.inc.sqf
@@ -1,4 +1,4 @@
-private _category = [LELSTRING(common,categoryUncategorized), localize "str_a3_gear1"];
+private _category = [format ["ACE %1", LELSTRING(ui,Category)], localize "str_a3_gear1"];
 
 [
     QGVAR(inventoryDisplaySize), "LIST",

--- a/addons/magazinerepack/initSettings.inc.sqf
+++ b/addons/magazinerepack/initSettings.inc.sqf
@@ -1,4 +1,4 @@
-private _category = format ["ACE %1", localize LSTRING(DisplayName)];
+private _category = [ELSTRING(common,ACEKeybindCategoryWeapons), LLSTRING(DisplayName)];
 
 [
     QGVAR(timePerAmmo), "SLIDER",

--- a/addons/maptools/initSettings.inc.sqf
+++ b/addons/maptools/initSettings.inc.sqf
@@ -1,4 +1,4 @@
-private _category = format ["ACE %1", LLSTRING(Name)];
+private _category = [format ["ACE %1", LELSTRING(map,Module_DisplayName)], LLSTRING(Name)];
 
 [
     QGVAR(rotateModifierKey), "LIST",

--- a/addons/marker_flags/initSettings.inc.sqf
+++ b/addons/marker_flags/initSettings.inc.sqf
@@ -1,4 +1,4 @@
-private _category = [LELSTRING(common,categoryUncategorized), LLSTRING(DisplayName_Settings)];
+private _category = [LELSTRING(common,ACEKeybindCategoryEquipment), LLSTRING(DisplayName_Settings)];
 
 [
     QGVAR(placeAnywhere), "CHECKBOX",

--- a/addons/markers/initSettings.inc.sqf
+++ b/addons/markers/initSettings.inc.sqf
@@ -1,9 +1,9 @@
-private _categoryName = format ["ACE %1", localize ELSTRING(map,Module_DisplayName)];
+private _category = [format ["ACE %1", LELSTRING(map,Module_DisplayName)], LLSTRING(Module_DisplayName)];
 
 [
     QGVAR(moveRestriction), "LIST",
     [LSTRING(MoveRestriction), LSTRING(MoveRestriction_Description)],
-    [_categoryName, LLSTRING(Module_DisplayName)],
+    _category,
     [
         [
             MOVE_RESTRICTION_NOBODY,
@@ -28,14 +28,14 @@ private _categoryName = format ["ACE %1", localize ELSTRING(map,Module_DisplayNa
 [
     QGVAR(timestampEnabled), "CHECKBOX",
     [LSTRING(TimestampEnabled), LSTRING(TimestampEnabledDescription)],
-    [_categoryName, LLSTRING(Module_DisplayName)],
+    _category,
     true
 ] call CBA_fnc_addSetting;
 
 [
     QGVAR(timestampTimezone), "LIST",
     [LSTRING(TimestampTimezone), LSTRING(TimestampTimezoneDescription)],
-    [_categoryName, LLSTRING(Module_DisplayName)],
+    _category,
     [
         [0, 1, 2],
         [LSTRING(TimestampTimezoneIngameTime), LSTRING(TimestampTimezoneSystemTime), LSTRING(TimestampTimezoneUTCTime)],
@@ -47,7 +47,7 @@ private _categoryName = format ["ACE %1", localize ELSTRING(map,Module_DisplayNa
 [
     QGVAR(timestampUTCOffset), "SLIDER",
     [LSTRING(TimestampUTCOffset), LSTRING(TimestampUTCOffsetDescription)],
-    [_categoryName, LLSTRING(Module_DisplayName)],
+    _category,
     [-12, 14, 0, 0],
     true
 ] call CBA_fnc_addSetting;
@@ -55,7 +55,7 @@ private _categoryName = format ["ACE %1", localize ELSTRING(map,Module_DisplayNa
 [
     QGVAR(TimestampUTCMinutesOffset), "LIST",
     [LSTRING(TimestampUTCMinutesOffset), LSTRING(TimestampUTCMinutesOffsetDescription)],
-    [_categoryName, LLSTRING(Module_DisplayName)],
+    _category,
     [
         [0, 15, 30, 45],
         [0, 15, 30, 45],
@@ -66,7 +66,7 @@ private _categoryName = format ["ACE %1", localize ELSTRING(map,Module_DisplayNa
 [
     QGVAR(timestampHourFormat), "LIST",
     [LSTRING(TimestampHourFormat), LSTRING(TimestampHourFormatDescription)],
-    [_categoryName, LLSTRING(Module_DisplayName)],
+    _category,
     [
         [24, 12],
         [LSTRING(TimestampHourFormat24), LSTRING(TimestampHourFormat12)],
@@ -86,7 +86,7 @@ private _formatDescription = [
 [
     QGVAR(timestampFormat), "LIST",
     [LSTRING(timestampFormat), _formatDescription],
-    [_categoryName, LLSTRING(Module_DisplayName)],
+    _category,
     [
         ["HH", "HH:MM", "HH:MM:SS", "HH:MM:SS:MM", "HH:MM:SS.mmm"],
         ["HH", "HH:MM", "HH:MM:SS", "HH:MM:SS:MM", "HH:MM:SS.mmm"],
@@ -97,6 +97,6 @@ private _formatDescription = [
 [
     QGVAR(quickNumberMarks), "LIST",
     [LSTRING(quickNumberMarks), LSTRING(quickNumberMarksDescription)],
-    [_categoryName, LLSTRING(Module_DisplayName)],
+    _category,
     [[0,1,2], [disabled, "STR_cba_settings_ButtonLocal", LSTRING(quickNumberMarksSideSync)], 2]
 ] call CBA_fnc_addSetting;

--- a/addons/microdagr/initSettings.inc.sqf
+++ b/addons/microdagr/initSettings.inc.sqf
@@ -1,4 +1,4 @@
-private _category = [LELSTRING(common,categoryUncategorized), LLSTRING(itemName)];
+private _category = [LELSTRING(common,ACEKeybindCategoryEquipment), LLSTRING(itemName)];
 
 [
     QGVAR(mapDataAvailable), "LIST",

--- a/addons/minedetector/initSettings.inc.sqf
+++ b/addons/minedetector/initSettings.inc.sqf
@@ -1,7 +1,7 @@
 [
     QGVAR(BoostRadius), "SLIDER",
     [LSTRING(BoostRadius), LSTRING(BoostRadius_Desc)],
-    format ["ACE %1", localize LSTRING(Category)],
+    [LELSTRING(common,ACEKeybindCategoryEquipment), LLSTRING(Category)],
     [0, 5, 0, 1],
     1
 ] call CBA_fnc_addSetting;

--- a/addons/optionsmenu/initSettings.inc.sqf
+++ b/addons/optionsmenu/initSettings.inc.sqf
@@ -1,4 +1,4 @@
-private _category = [LELSTRING(common,categoryUncategorized), LLSTRING(aceNews)];
+private _category = format ["ACE %1", LELSTRING(common,DisplayName)];
 
 [
     QGVAR(showNewsOnMainMenu), "CHECKBOX",

--- a/addons/overheating/initSettings.inc.sqf
+++ b/addons/overheating/initSettings.inc.sqf
@@ -1,4 +1,4 @@
-private _category = format ["ACE %1", localize LSTRING(DisplayName)];
+private _category = [ELSTRING(common,ACEKeybindCategoryWeapons), LSTRING(DisplayName)];
 
 [
     QGVAR(enabled), "CHECKBOX",

--- a/addons/parachute/initSettings.inc.sqf
+++ b/addons/parachute/initSettings.inc.sqf
@@ -1,4 +1,4 @@
-private _category = [LELSTRING(common,categoryUncategorized), localize "str_dn_parachute"];
+private _category = [LELSTRING(common,ACEKeybindCategoryEquipment), localize "str_dn_parachute"];
 
 [
     QGVAR(hideAltimeter),

--- a/addons/quickmount/initSettings.inc.sqf
+++ b/addons/quickmount/initSettings.inc.sqf
@@ -1,8 +1,10 @@
+private _category = [ELSTRING(common,ACEKeybindCategoryVehicles), LLSTRING(Category)];
+
 [
     QGVAR(enabled),
     "CHECKBOX",
     [ELSTRING(common,Enabled), LSTRING(EnabledDescription)],
-    format ["ACE %1", LLSTRING(Category)],
+    _category,
     true,
     true
 ] call CBA_fnc_addSetting;
@@ -11,7 +13,7 @@
     QGVAR(distance),
     "SLIDER",
     [LSTRING(Distance), LSTRING(DistanceDescription)],
-    format ["ACE %1", LLSTRING(Category)],
+    _category,
     [0, 10, DEFAULT_DISTANCE, 0],
     true
 ] call CBA_fnc_addSetting;
@@ -20,7 +22,7 @@
     QGVAR(speed),
     "SLIDER",
     [LSTRING(Speed), LSTRING(SpeedDescription)],
-    format ["ACE %1", LLSTRING(Category)],
+    _category,
     [0, 30, DEFAULT_SPEED, 0],
     true
 ] call CBA_fnc_addSetting;
@@ -29,7 +31,7 @@
     QGVAR(priority),
     "LIST",
     [LSTRING(Priority), LSTRING(PriorityDescription)],
-    format ["ACE %1", LLSTRING(Category)],
+    _category,
     [[0, 1, 2, 3], ["str_getin_pos_driver", "str_getin_pos_gunn", "str_getin_pos_comm", "str_getin_pos_passenger"], DEFAULT_PRIORITY],
     false
 ] call CBA_fnc_addSetting;
@@ -38,7 +40,7 @@
     QGVAR(enableMenu),
     "LIST",
     ELSTRING(interact_menu,Category_InteractionMenu),
-    format ["ACE %1", LLSTRING(Category)],
+    _category,
     [
         [0,1,2,3],
         [

--- a/addons/sitting/initSettings.inc.sqf
+++ b/addons/sitting/initSettings.inc.sqf
@@ -2,7 +2,7 @@
     QXGVAR(enable),
     "CHECKBOX",
     [LSTRING(Enable), LSTRING(ModuleDescription)],
-    format ["ACE %1", LLSTRING(ModuleDisplayName)],
+    [LELSTRING(common,categoryUncategorized), LLSTRING(ModuleDisplayName)],
     true,
     true,
     {[QGVAR(enable), _this] call EFUNC(common,cbaSettings_settingChanged)},

--- a/addons/vehicle_damage/initSettings.inc.sqf
+++ b/addons/vehicle_damage/initSettings.inc.sqf
@@ -1,8 +1,10 @@
+private _category = [ELSTRING(common,ACEKeybindCategoryVehicles), LLSTRING(category_displayName)];
+
 [
     QGVAR(enabled),
     "CHECKBOX",
     [ELSTRING(common,Enabled), LSTRING(setting_description)],
-    LSTRING(category_displayName),
+    _category,
     false,
     1,
     {[QGVAR(enabled), _this] call EFUNC(common,cbaSettings_settingChanged)},
@@ -13,7 +15,7 @@
     QGVAR(enableCarDamage),
     "CHECKBOX",
     [LSTRING(carDamage_setting_enable), LSTRING(carDamage_setting_description)],
-    LSTRING(category_displayName),
+    _category,
     false,
     1,
     {[QGVAR(enableCarDamage), _this] call EFUNC(common,cbaSettings_settingChanged)},

--- a/addons/vehicle_damage/stringtable.xml
+++ b/addons/vehicle_damage/stringtable.xml
@@ -30,18 +30,18 @@
             <Ukrainian>Увімкнути розширене пошкодження автомобіля</Ukrainian>
         </Key>
         <Key ID="STR_ACE_Vehicle_Damage_category_displayName">
-            <English>ACE Advanced Vehicle Damage</English>
-            <French>ACE Dégâts de véhicule avancés</French>
-            <Spanish>ACE Daño avanzado de vehículos</Spanish>
-            <Italian>ACE Danni Veicolo Avanzati</Italian>
-            <Polish>ACE Zaawansowany system uszkodzeń pojazdów</Polish>
-            <Portuguese>ACE Dano avançãdo de veículos</Portuguese>
-            <Russian>ACE Продвинутое повреждение техники</Russian>
-            <German>ACE Erweiterter Fahrzeugsschaden</German>
-            <Korean>ACE 고급 차량 피해</Korean>
-            <Japanese>ACE 高度な乗り物ダメージ</Japanese>
-            <Chinesesimp>ACE 高级载具损坏</Chinesesimp>
-            <Ukrainian>ACE Розширене пошкодження техніки</Ukrainian>
+            <English>Advanced Vehicle Damage</English>
+            <French>Dégâts de véhicule avancés</French>
+            <Spanish>Daño avanzado de vehículos</Spanish>
+            <Italian>Danni Veicolo Avanzati</Italian>
+            <Polish>Zaawansowany system uszkodzeń pojazdów</Polish>
+            <Portuguese>Dano avançãdo de veículos</Portuguese>
+            <Russian>Продвинутое повреждение техники</Russian>
+            <German>Erweiterter Fahrzeugsschaden</German>
+            <Korean>고급 차량 피해</Korean>
+            <Japanese>高度な乗り物ダメージ</Japanese>
+            <Chinesesimp>高级载具损坏</Chinesesimp>
+            <Ukrainian>Розширене пошкодження техніки</Ukrainian>
         </Key>
         <Key ID="STR_ACE_Vehicle_Damage_generic_turret_wreck">
             <English>Wreck (Turret)</English>

--- a/addons/vehiclelock/initSettings.inc.sqf
+++ b/addons/vehiclelock/initSettings.inc.sqf
@@ -1,7 +1,9 @@
+private _category = [ELSTRING(common,ACEKeybindCategoryVehicles), LLSTRING(DisplayName)];
+
 [
     QGVAR(defaultLockpickStrength), "SLIDER",
     [LSTRING(DefaultLockpickStrength_DisplayName), LSTRING(DefaultLockpickStrength_Description)],
-    LSTRING(DisplayName),
+    _category,
     [-1,60,10,1], // [min, max, default value, trailing decimals (-1 for whole numbers only)]
     true // isGlobal
 ] call CBA_fnc_addSetting;
@@ -9,7 +11,7 @@
 [
     QGVAR(lockVehicleInventory), "CHECKBOX",
     [LSTRING(LockVehicleInventory_DisplayName), LSTRING(LockVehicleInventory_Description)],
-    LSTRING(DisplayName),
+    _category,
     false, // default value
     true, // isGlobal
     {[QGVAR(lockVehicleInventory), _this] call EFUNC(common,cbaSettings_settingChanged)},
@@ -19,7 +21,7 @@
 [
     QGVAR(vehicleStartingLockState), "LIST",
     [LSTRING(VehicleStartingLockState_DisplayName), LSTRING(VehicleStartingLockState_Description)],
-    LSTRING(DisplayName),
+    _category,
     [[-1,0,1,2],[LSTRING(VehicleStartingLockState_AsIs), LSTRING(VehicleStartingLockState_RemoveAmbiguousLockState), LSTRING(VehicleStartingLockState_Locked), LSTRING(VehicleStartingLockState_Unlocked)], 0], // [values, titles, defaultIndex]
     true, // isGlobal
     {[QGVAR(vehicleStartingLockState), _this] call EFUNC(common,cbaSettings_settingChanged)},

--- a/addons/vehiclelock/stringtable.xml
+++ b/addons/vehiclelock/stringtable.xml
@@ -109,21 +109,21 @@
             <Ukrainian>Сила відмички за замовчуванням</Ukrainian>
         </Key>
         <Key ID="STR_ACE_VehicleLock_DisplayName">
-            <English>ACE Vehicle Lock</English>
-            <Czech>ACE Zamykání Vozidel</Czech>
-            <French>ACE Verrouillage véhicule</French>
-            <Spanish>ACE Bloqueo de vehículo</Spanish>
-            <Italian>ACE Blocco Veicolo</Italian>
-            <Polish>ACE Zamknięcie Pojazdu</Polish>
-            <Portuguese>ACE Trancar Veículos</Portuguese>
-            <Russian>ACE Блокировка транспорта</Russian>
-            <German>ACE Fahrzeugsperre</German>
-            <Korean>ACE 차량 잠금</Korean>
-            <Japanese>ACE 車両の施錠</Japanese>
-            <Chinese>ACE 載具上鎖</Chinese>
-            <Chinesesimp>ACE 载具上锁</Chinesesimp>
-            <Turkish>ACE Araç Kilidi</Turkish>
-            <Ukrainian>ACE Блокування транспорту</Ukrainian>
+            <English>Vehicle Lock</English>
+            <Czech>Zamykání Vozidel</Czech>
+            <French>Verrouillage véhicule</French>
+            <Spanish>Bloqueo de vehículo</Spanish>
+            <Italian>Blocco Veicolo</Italian>
+            <Polish>Zamknięcie Pojazdu</Polish>
+            <Portuguese>Trancar Veículos</Portuguese>
+            <Russian>Блокировка транспорта</Russian>
+            <German>Fahrzeugsperre</German>
+            <Korean>차량 잠금</Korean>
+            <Japanese>車両の施錠</Japanese>
+            <Chinese>載具上鎖</Chinese>
+            <Chinesesimp>载具上锁</Chinesesimp>
+            <Turkish>Araç Kilidi</Turkish>
+            <Ukrainian>Блокування транспорту</Ukrainian>
         </Key>
         <Key ID="STR_ACE_VehicleLock_Item_Civ_Description">
             <English>A key that should open most CIV vehicle.</English>


### PR DESCRIPTION
**When merged this pull request will:**
- add `Equipment` category;
- move some categories to `Equipment`, `Map`, `Uncategorized`, `User Interface`, `Vehicles`, `Weapons`.

Can move more settings to categories, but not sure if needed/appropriate:
**Interaction**
Dragging
Sitting

**Weapons**
Adv Throwing

**Units** (new category)
Captives
Respawn
Switch Units

**Equipment**
Scopes
Trenches
Tagging
Wardrobe

**Sound** (new category)
Hearing
Volume
No Radio
Common - Allow turning down music

**User Interface**
Common - icon + progress bar + epilepsy settings

**Logistics**
Pylons

**Vehicles**
Fast-roping

**Effects** (new category)
Cook-off
Field Rations ?
Fire
Fragmentation Simulation
G-Forces
Nightvision (Equipment ?)
Hit Reactions
Overheating (Weapons ?)
Overpressure
Pointing ?
View Distance Limiter ?
View Restriction ?
Weather ?
Wind Deflection ?