### PR TITLE
Reload - Increase distance for base interaction "ACE_Weapon" from 1.5 to 2.0

### DIFF
--- a/addons/interaction/CfgVehicles.hpp
+++ b/addons/interaction/CfgVehicles.hpp
@@ -230,7 +230,7 @@ class CfgVehicles {
             class ACE_Weapon {
                 displayName = CSTRING(Weapon);
                 position = QUOTE(call DFUNC(getWeaponPos));
-                distance = 1.50;
+                distance = 2;
                 condition = "";
                 statement = "";
                 exceptions[] = {"isNotSwimming"};


### PR DESCRIPTION
## Motivation

As an MG assitant, more often then not, i had issues reaching the Gunner's Gun's Ace Interaction Node to link the belts, even when im directly next to them. Even when in range, a simple twitch/turn from the gunner can move the action point out of range again.

The reload action "check ammo" and "link belt" have a range of 2 meters defined, but the range of the base interaction `ACE_Weapon` has a range of 1.5.

To compare, one can open a units backpack from 3 meters which feels as intrusive/hands-on as working on the gun itself.

## Changes
class ACE_Weapon distance: 1.5 -> 2.0