### PR TITLE
Fire - Add fire source to burning fuel pump

### DIFF
--- a/addons/fire/XEH_postInit.sqf
+++ b/addons/fire/XEH_postInit.sqf
@@ -36,6 +36,28 @@
 
     if (!isServer) exitWith {};
 
+    addMissionEventHandler ["BuildingChanged", {
+        params ["_pump", "_ruin", "_isRuin"];
+        if (
+            !_isRuin // partial destruction
+            || {!isNull _ruin} // pump with ruin has endless effects
+            || {getNumber (configOf _pump >> "transportFuel") == 0} // getFuelCargo returns 0 for any dead object
+        ) exitWith {};
+
+        // while pump going down under terrain, effect can be up to 3m away
+        private _hasEffectsCode = {_this nearObjects ["#destructioneffects", 3] isNotEqualTo []};
+        TRACE_2("BuildingChanged",_pump,_pump call _hasEffectsCode);
+
+        [QGVAR(addFireSource), [
+            getPosASL _pump, // pump goes under terrain when destroyed, use position
+            4 max (boundingBoxReal [_pump, "FireGeometry"] select 2),
+            8,
+            QGVAR(wreck) + hashValue _pump,
+            _hasEffectsCode,
+            _pump
+        ]] call CBA_fnc_localEvent;
+    }];
+
     GVAR(fireSources) = createHashMap;
 
     [QGVAR(addFireSource), {


### PR DESCRIPTION
**When merged this pull request will:**
- title.

Requires #11416 or disabled refuel setting.

`getEntityInfo` does not support `Static` vehicles. The workaround is to detect `#destructioneffects` objects near a burning fuel pump.

The only issue I found is with pumps that have a configured ruin, such as CUP `Land_Fuelstation` and `Land_Fuelstation_army`. Their destruction effects never end, so I had to disable support for them.

I also wanted to add support for `Thing` objects (`B_Slingload_01_Fuel_F`, `Land_Pod_Heli_Transport_04_fuel_F`, and CUP `Barrel`). They also spawn `#destructioneffects` objects within about 1 m. However, I couldn't find a reliable way to calculate the detection radius from their bounding boxes. I decided to drop the idea.

Tested in SP and dedicated, both local and remote pumps.