### PR TITLE
Hearing - Remove deafness from vehicle secondary explosions

### DIFF
--- a/addons/hearing/XEH_postInit.sqf
+++ b/addons/hearing/XEH_postInit.sqf
@@ -20,6 +20,7 @@ if (isServer) then {
         [{ // Convert ace_common's local explosion to a hearing global explosion event
             params ["_projectile", "_pos"];
             TRACE_1("Explode",_this);
+            if (typeOf _projectile isEqualTo "SmallSecondary") exitWith {};
 
             // If projectile is local only, don't raise event globally
             if ((netId _projectile) == "0:0") then {
@@ -30,7 +31,9 @@ if (isServer) then {
         }] call EFUNC(common,addExplosionEventHandler);
     } else {
         [{
+            params ["_projectile"];
             TRACE_1("Explode",_this);
+            if (typeOf _projectile isEqualTo "SmallSecondary") exitWith {};
             [QGVAR(explosion), _this] call CBA_fnc_localEvent;
         }] call EFUNC(common,addExplosionEventHandler);
     };

--- a/addons/hearing/functions/fnc_handleVehicleKilled.sqf
+++ b/addons/hearing/functions/fnc_handleVehicleKilled.sqf
@@ -27,14 +27,22 @@ if (_distance > 50) exitWith {};
 // Calculate explosion power
 // This formula was once revealed to me in a dream
 private _cfg = configOf _vehicle;
-private _explosionPower = getNumber (_cfg >> "secondaryExplosion");
-if (_explosionPower == 0) exitWith {};
+private _secondaryExplosion = getNumber (_cfg >> "secondaryExplosion");
+if (_secondaryExplosion == 0) exitWith {};
 
-if (_explosionPower < 0) then {
-    private _fuelCargoPower = (getFuelCargo _vehicle max 0) * getNumber (_cfg >> "transportFuel") * 0.1;
-    private _fuelPower = fuel _vehicle * getNumber (_cfg >> "fuelCapacity") * 0.1;
+private _explosionPower = _secondaryExplosion;
+if (_secondaryExplosion < 0) then {
+    private _ammoCargoPower = 0;
+    private _transportAmmo = getNumber (_cfg >> "transportAmmo");
+    if (_transportAmmo > 0) then {
+        private _ammoCargo = if (["ace_rearm"] call EFUNC(common,isModLoaded) && {EGVAR(rearm,enabled)}) then {
+            1 // ignoring rearm level
+        } else {
+            getAmmoCargo _vehicle max 0
+        };
+        _ammoCargoPower = _ammoCargo * _transportAmmo * 0.05;
+    };
 
-    private _ammoCargoPower = (getAmmoCargo _vehicle max 0) * getNumber (_cfg >> "transportAmmo") * 0.05;
     private _ammoPower = 0;
     private _magCache = createHashMap;
     {
@@ -47,10 +55,11 @@ if (_explosionPower < 0) then {
         _ammoPower = _ammoPower + _hit * _count * 0.015;
     } forEach magazinesAmmoFull _vehicle;
 
-    _explosionPower = abs _explosionPower * (_ammoCargoPower + _fuelCargoPower + _fuelPower + _ammoPower);
+    _explosionPower = abs _secondaryExplosion * (_ammoCargoPower + _ammoPower);
 };
 
 private _powerCoef = getNumber (_cfg >> "fuelExplosionPower");
+TRACE_5("VehicleKilled",_vehicle,_distance,_secondaryExplosion,_explosionPower,_powerCoef);
 
 // A low explosion power causes no immediate audible explosion
 // Number + coef mechanics found through extensive testing


### PR DESCRIPTION
**When merged this pull request will:**
- remove deafness from vehicle secondary explosions;
- exclude fuel (both tank fuel and cargo fuel) from the explosion power calculation;
- fix cargo ammo in the explosion power calculation when ACE Rearm is enabled.

AFAIK, fuel does not explode when a vehicle is destroyed. It burns, but it does not produce a loud explosion.
A secondary explosion from a vehicle without ammunition is not loud enough to cause deafness. There may be occasional pops from burning tires or pneumatics, but there is no actual explosion.
Since ammunition explosions are already handled by `cookoff`, secondary explosion deafness should be disabled.

When ACE Rearm is enabled, `getAmmoCargo` returns `0` for every rearm vehicle. This causes `_ammoCargoPower` to be `0` as well. This is now handled by treating the value as `1` instead.