### PR TITLE
Vehicle Damage - Add static weapon crew ejection on destruction

### DIFF
--- a/addons/vehicle_damage/XEH_postInit.sqf
+++ b/addons/vehicle_damage/XEH_postInit.sqf
@@ -15,6 +15,12 @@
     }, true, [], true] call CBA_fnc_addClassEventHandler;
 } forEach EJECT_IF_DESTROYED_VEHICLES;
 
+["StaticWeapon", "Init", {
+    params ["_vehicle"];
+    if (getNumber (configOf _vehicle >> "ejectDeadCargo") == 0) exitWith {}; // Pod_Heli_Transport_04_crewed_base_F
+    _vehicle addEventHandler ["HandleDamage", {call FUNC(handleDamageEjectIfDestroyed)}];
+}, true, [], true] call CBA_fnc_addClassEventHandler;
+
 ["CBA_settingsInitialized", {
     TRACE_1("settings init",GVAR(enabled));
 

--- a/addons/vehicle_damage/functions/fnc_handleDamageEjectIfDestroyed.sqf
+++ b/addons/vehicle_damage/functions/fnc_handleDamageEjectIfDestroyed.sqf
@@ -16,19 +16,40 @@
  * Public: No
  */
 
-params ["_vehicle", "", "", "", "_ammo"];
+params ["_vehicle", "_selection", "_damage", "", "_projectile"];
 
-if (alive _vehicle) exitWith {};
+if (
+    alive _vehicle
+    && {_selection isNotEqualTo "" || {_damage < 1}} // overall structural damage
+) exitWith {};
 
-TRACE_2("handleDamageEjectIfDestroyed",typeOf _vehicle,_this);
-
-if (IS_INEXPLOSIVE_AMMO(_ammo)) then {
-    {
-        if (alive _x) then {
-            moveOut _x;
-        };
-    } forEach crew _vehicle;
-};
+TRACE_5("handleDamageEjectIfDestroyed",alive _vehicle,speed _vehicle,velocity _vehicle,typeOf _vehicle,_this);
 
 //IGNORE_PRIVATE_WARNING ["_thisEventHandler"];
 _vehicle removeEventHandler ["HandleDamage", _thisEventHandler];
+
+if (_projectile isNotEqualTo "") exitWith {
+    if (IS_INEXPLOSIVE_AMMO(_projectile)) then {
+        {
+            moveOut _x;
+        } forEach crew _vehicle;
+    };
+};
+
+if (_vehicle isKindOf "StaticWeapon") exitWith {
+    {
+        moveOut _x;
+    } forEach crew _vehicle;
+};
+
+// boat collision damage
+{
+    moveOut _x;
+    private _posASL = getPosASLW _x;
+    // if moved out under water, move it upper
+    if (_posASL select 2 < 0.5) then {
+        TRACE_3("move up",_x,_posASL select 2,velocity _x);
+        _posASL set [2, 0.5];
+        _x setPosASLW _posASL;
+    };
+} forEach crew _vehicle;


### PR DESCRIPTION
**When merged this pull request will:**
- add static weapon crew ejection on destruction;
- improve `fnc_handleDamageEjectIfDestroyed` by running it at the last alive moment;
- improve boat crew ejection when a boat is destroyed after a collision.

The HandleDamage EH now runs not only after the vehicle is destroyed, but also at the last moment while it is still alive and overall damage is critical. In most cases this happens in the same frame, but the "alive" moment occurs slightly earlier and is more reliable.

Previously, when a boat was destroyed after a collision, its crew was simply ejected. In some cases they were ejected directly into the water, so the boat's velocity was not transferred to them. Now the crew is ejected slightly above the water, allowing them to retain the boat's momentum and potentially be thrown into the rocks or the pier that destroyed the boat.