### PR TITLE
Nightvision - Add support for helmet integrated devices

### DIFF
--- a/addons/nightvision/CfgWeapons.hpp
+++ b/addons/nightvision/CfgWeapons.hpp
@@ -33,6 +33,18 @@ class CfgWeapons {
         modelOptics = "";
         displayName = CSTRING(NVG_Gen3_black);
     };
+	class Integrated_NVG_F: NVGoggles {
+		GVAR(border) = "";
+		GVAR(generation) = 4;
+	};
+	class Integrated_NVG_TI_0_F: NVGoggles {
+		GVAR(border) = "";
+		GVAR(generation) = 4;
+	};
+	class Integrated_NVG_TI_1_F: NVGoggles {
+		GVAR(border) = "";
+		GVAR(generation) = 4;
+	};
     class ACE_NVGoggles_OPFOR_WP: NVGoggles_OPFOR {
         displayName = CSTRING(NVG_Gen3_black_WP);
         descriptionShort = CSTRING(NVG_WP_desc);

--- a/addons/nightvision/CfgWeapons.hpp
+++ b/addons/nightvision/CfgWeapons.hpp
@@ -154,6 +154,44 @@ class CfgWeapons {
     };
 
 
+	class ACE_Integrated_NVG_WP : Integrated_NVG_F {
+		NVG_WHITE_PRESET;
+	};
+	class ACE_Integrated_NVG_TI_0_WP : Integrated_NVG_TI_0_F {
+		NVG_WHITE_PRESET;
+	};
+	class ACE_Integrated_NVG_TI_1_WP : Integrated_NVG_TI_1_F {
+		NVG_WHITE_PRESET;
+	};
+
+	class H_PilotHelmetFighter_B;
+	class H_PilotHelmetFighter_I;
+	class H_PilotHelmetFighter_O;
+	class ACE_H_PilotHelmetFighter_B_WP : H_PilotHelmetFighter_B {
+		displayName = CSTRING(H_PilotHelmetFighter_B_WP);
+		subItems[] = {"ACE_Integrated_NVG_WP"};
+	};
+	class ACE_H_PilotHelmetFighter_I_WP : H_PilotHelmetFighter_I {
+		displayName = CSTRING(H_PilotHelmetFighter_I_WP);
+		subItems[] = {"ACE_Integrated_NVG_WP"};
+	};
+	class ACE_H_PilotHelmetFighter_O_WP : H_PilotHelmetFighter_O {
+		displayName = CSTRING(H_PilotHelmetFighter_O_WP);
+		subItems[] = {"ACE_Integrated_NVG_WP"};
+	};
+
+	class H_HelmetO_ViperSP_hex_F;
+	class H_HelmetO_ViperSP_ghex_F;
+	class ACE_H_HelmetO_ViperSP_hex_WP : H_HelmetO_ViperSP_hex_F {
+		displayName = CSTRING(H_HelmetO_ViperSP_hex_WP);
+		subItems[] = {"ACE_Integrated_NVG_TI_1_WP"};
+	};
+	class ACE_H_HelmetO_ViperSP_ghex_WP : H_HelmetO_ViperSP_ghex_F {
+		displayName = CSTRING(H_HelmetO_ViperSP_ghex_WP);
+		subItems[] = {"ACE_Integrated_NVG_TI_1_WP"};
+	};
+
+
     // Examples of different goggle effect types (scope=1)
     // These all function differently, but we have no models to go with them
     class ACE_NVG_Biocular: NVGoggles {

--- a/addons/nightvision/CfgWeapons.hpp
+++ b/addons/nightvision/CfgWeapons.hpp
@@ -35,15 +35,15 @@ class CfgWeapons {
     };
 	class Integrated_NVG_F: NVGoggles {
 		GVAR(border) = "";
-		GVAR(generation) = 4;
+		GVAR(generation) = -1;
 	};
 	class Integrated_NVG_TI_0_F: NVGoggles {
 		GVAR(border) = "";
-		GVAR(generation) = 4;
+		GVAR(generation) = -1;
 	};
 	class Integrated_NVG_TI_1_F: NVGoggles {
 		GVAR(border) = "";
-		GVAR(generation) = 4;
+		GVAR(generation) = -1;
 	};
     class ACE_NVGoggles_OPFOR_WP: NVGoggles_OPFOR {
         displayName = CSTRING(NVG_Gen3_black_WP);

--- a/addons/nightvision/XEH_postInit.sqf
+++ b/addons/nightvision/XEH_postInit.sqf
@@ -38,6 +38,18 @@ GVAR(isUsingMagnification) = false;
     ["unit", {
         // Call manually to update existing value
         GVAR(playerHMD) = hmd ace_player;
+		if ((hmd ace_player) isEqualTo "") then {
+			if (headgear ace_player isNotEqualTo "") then {
+				private _subItems = getArray (configFile >> "CfgWeapons" >> (headgear ace_player) >> "subItems");
+				if (_subItems isEqualTo []) exitWith {};
+				private _nvg = _subItems findIf { "nvg" in (toLower _x) };
+				if (_nvg isEqualTo -1) exitWith {};
+				[{
+					GVAR(playerHMD) = (_this select 0);
+					[] call FUNC(refreshGoggleType);
+				},[(_subItems select _nvg)]] call CBA_fnc_execNextFrame;
+			};
+		};
 
         // Fix overlay not being present when switching units
         if (GVAR(running)) then {

--- a/addons/nightvision/config.cpp
+++ b/addons/nightvision/config.cpp
@@ -26,7 +26,12 @@ class CfgPatches {
             "ACE_NVGoggles_INDEP_WP",
             "ACE_NVG_Wide_Black_WP",
             "ACE_NVG_Wide_WP",
-            "ACE_NVG_Wide_Green_WP"
+            "ACE_NVG_Wide_Green_WP",
+			"ACE_H_PilotHelmetFighter_B_WP",
+			"ACE_H_PilotHelmetFighter_I_WP",
+			"ACE_H_PilotHelmetFighter_O_WP",
+			"ACE_H_HelmetO_ViperSP_hex_WP",
+			"ACE_H_HelmetO_ViperSP_ghex_WP"
         };
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common"};

--- a/addons/nightvision/functions/fnc_onSlotItemChanged.sqf
+++ b/addons/nightvision/functions/fnc_onSlotItemChanged.sqf
@@ -23,6 +23,11 @@ TRACE_4("onSlotItemChanged",_unit,_item,_slot,_assign);
 
 if (_slot != TYPE_HMD) exitWith {
     if (_slot != TYPE_HEADGEAR && {(hmd _unit) isEqualTo ""}) exitWith {};
+    if (!_assign) exitWith {
+        if ((hmd _unit) isEqualTo "") exitWith {
+            GVAR(playerHMD) = "";
+        };
+    };
     private _subItems = getArray (configFile >> "CfgWeapons" >> _item >> "subItems");
     if (_subItems isEqualTo []) exitWith {};
     private _nvg = _subItems findIf { "nvg" in (toLower _x) };

--- a/addons/nightvision/functions/fnc_onSlotItemChanged.sqf
+++ b/addons/nightvision/functions/fnc_onSlotItemChanged.sqf
@@ -21,7 +21,17 @@
 params ["_unit", "_item", "_slot", "_assign"];
 TRACE_4("onSlotItemChanged",_unit,_item,_slot,_assign);
 
-if (_slot != TYPE_HMD) exitWith {};
+if (_slot != TYPE_HMD) exitWith {
+    if (_slot != TYPE_HEADGEAR && {(hmd _unit) isEqualTo ""}) exitWith {};
+    private _subItems = getArray (configFile >> "CfgWeapons" >> _item >> "subItems");
+    if (_subItems isEqualTo []) exitWith {};
+    private _nvg = _subItems findIf { "nvg" in (toLower _x) };
+    if (_nvg isEqualTo -1) exitWith {};
+    [{
+        GVAR(playerHMD) = (_this select 0);
+        [] call FUNC(refreshGoggleType);
+    },[(_subItems select _nvg)]] call CBA_fnc_execNextFrame;
+};
 
 if (!_assign) exitWith {
     GVAR(playerHMD) = "";

--- a/addons/nightvision/functions/fnc_pfeh.sqf
+++ b/addons/nightvision/functions/fnc_pfeh.sqf
@@ -66,14 +66,16 @@ if (IS_MAGNIFIED isNotEqualTo GVAR(isUsingMagnification)) then {
 };
 
 if (CBA_missionTime < GVAR(nextEffectsUpdate)) then {
-    // Update radial blur as it depends on zoom level, so should be changed each frame like the border/hex
-    if (GVAR(ppeffectRadialBlur) != -1) then {
-        GVAR(ppeffectRadialBlur) ppEffectAdjust [.005, .005, _scale * GVAR(nvgBlurRadius), _scale * .16];
-        GVAR(ppeffectRadialBlur) ppEffectCommit 0;
-    };
-    // Need to rapidly update fog or it will try to resync from the server
-    if (GVAR(fogScaling) > 0) then {
-        0 setFog GVAR(nvgFog);
+    if (GVAR(nvgGeneration) > -1) then {
+        // Update radial blur as it depends on zoom level, so should be changed each frame like the border/hex
+        if (GVAR(ppeffectRadialBlur) != -1) then {
+            GVAR(ppeffectRadialBlur) ppEffectAdjust [.005, .005, _scale * GVAR(nvgBlurRadius), _scale * .16];
+            GVAR(ppeffectRadialBlur) ppEffectCommit 0;
+        };
+        // Need to rapidly update fog or it will try to resync from the server
+        if (GVAR(fogScaling) > 0) then {
+            0 setFog GVAR(nvgFog);
+        };
     };
 } else {
     // Redo full effects less often
@@ -120,24 +122,54 @@ if (CBA_missionTime < GVAR(nextEffectsUpdate)) then {
     // Setup all effects
     // This is hacky but... works. This prevents the effects from being cancelled by various things - alt-tabbing, resizing, going into AT sights, etc. A nicer method would be welcome but I don't have time to spend on it. TODO.
 
-    // FilmGrain - Electronic Noise
-    // Params: [intensity(0..1), sharpness(0..20), grainsize(1..8), intensityX0, intensityX1, monochromatic(bool)]
-    GVAR(ppeffectGrain) = ppEffectCreate ["FilmGrain", 200];
-    GVAR(ppeffectGrain) ppEffectAdjust [_grainIntensityFinal, _noiseSharpnessFinal, _grainFinal, 0.3, 0.3];
-    // OldNVG:  [0.25, 2.5, 2.5, _grainSetting, _grainSetting, false]
-    GVAR(ppeffectGrain) ppEffectCommit 0;
-    GVAR(ppeffectGrain) ppEffectForceInNVG true;
-    GVAR(ppeffectGrain) ppEffectEnable true;
 
-    // RadialBlur - Blurs closer to the edge nvg border (radius based on GVAR(bluRadius) config; e.g. larger for quadtube)
-    // Note: "Will not do anything if RADIAL BLUR is disabled in Video Options." - So should try to keep this effect to a minimum to prevent balance issues
-    // Params: [powerX, powerY, offsetX, offsetY]
-    if (GVAR(nvgBlurRadius) != -1) then {
-        GVAR(ppeffectRadialBlur) = ppEffectCreate ["RadialBlur", 451];
-        GVAR(ppeffectRadialBlur) ppEffectAdjust [_radialBlurPower, _radialBlurPower, _scale * GVAR(nvgBlurRadius), _scale * .16];
-        GVAR(ppeffectRadialBlur) ppEffectCommit 0;
-        GVAR(ppeffectRadialBlur) ppEffectForceInNVG true;
-        GVAR(ppeffectRadialBlur) ppEffectEnable true;
+    if (GVAR(nvgGeneration) > -1) then {
+        // FilmGrain - Electronic Noise
+        // Params: [intensity(0..1), sharpness(0..20), grainsize(1..8), intensityX0, intensityX1, monochromatic(bool)]
+        GVAR(ppeffectGrain) = ppEffectCreate ["FilmGrain", 200];
+        GVAR(ppeffectGrain) ppEffectAdjust [_grainIntensityFinal, _noiseSharpnessFinal, _grainFinal, 0.3, 0.3];
+        // OldNVG:  [0.25, 2.5, 2.5, _grainSetting, _grainSetting, false]
+        GVAR(ppeffectGrain) ppEffectCommit 0;
+        GVAR(ppeffectGrain) ppEffectForceInNVG true;
+        GVAR(ppeffectGrain) ppEffectEnable true;
+
+        // RadialBlur - Blurs closer to the edge nvg border (radius based on GVAR(bluRadius) config; e.g. larger for quadtube)
+        // Note: "Will not do anything if RADIAL BLUR is disabled in Video Options." - So should try to keep this effect to a minimum to prevent balance issues
+        // Params: [powerX, powerY, offsetX, offsetY]
+        if (GVAR(nvgBlurRadius) != -1) then {
+            GVAR(ppeffectRadialBlur) = ppEffectCreate ["RadialBlur", 451];
+            GVAR(ppeffectRadialBlur) ppEffectAdjust [_radialBlurPower, _radialBlurPower, _scale * GVAR(nvgBlurRadius), _scale * .16];
+            GVAR(ppeffectRadialBlur) ppEffectCommit 0;
+            GVAR(ppeffectRadialBlur) ppEffectForceInNVG true;
+            GVAR(ppeffectRadialBlur) ppEffectEnable true;
+        };
+
+        // DynamicBlur - Increases overall screen blur when aiming down sights (which would be hard/impossible with NVG)
+        // Params: [value(0..inf)]
+        GVAR(ppeffectBlur) = ppEffectCreate ["DynamicBlur", 190];
+        GVAR(ppeffectBlur) ppEffectAdjust [_blurFinal];
+        GVAR(ppeffectBlur) ppEffectCommit 0;
+        GVAR(ppeffectBlur) ppEffectForceInNVG true;
+        GVAR(ppeffectBlur) ppEffectEnable true;
+
+
+        // Modify local fog:
+        if (GVAR(fogScaling) > 0) then {
+            private _vehicle = vehicle _unit;
+
+            if (_vehicle != _unit && {_vehicle isKindOf "Air"}) then {  // For flying in particular, can refine nicer later.
+                _fogApply = _fogApply * ST_NVG_AIR_FOG_MULTIPLIER;
+            };
+
+            _fogApply = linearConversion [0, 1, GVAR(priorFog) select 0, (GVAR(fogScaling) * _fogApply), 1]; // mix in old fog if present
+            GVAR(nvgFog) = fogParams;
+            GVAR(nvgFog) set [0, _fogApply];
+
+            0 setFog GVAR(nvgFog)
+        };
+    } else {
+        _brightFinal = ST_NVG_BRIGHT_MAX + (_playerBrightSetting / 20);
+        _contrastFinal = 1;
     };
 
     // ColorCorrections - Changes brightness, contrast and "green" color of nvg
@@ -147,30 +179,6 @@ if (CBA_missionTime < GVAR(nextEffectsUpdate)) then {
     GVAR(ppeffectColorCorrect) ppEffectCommit 0;
     GVAR(ppeffectColorCorrect) ppEffectForceInNVG true;
     GVAR(ppeffectColorCorrect) ppEffectEnable true;
-
-    // DynamicBlur - Increases overall screen blur when aiming down sights (which would be hard/impossible with NVG)
-    // Params: [value(0..inf)]
-    GVAR(ppeffectBlur) = ppEffectCreate ["DynamicBlur", 190];
-    GVAR(ppeffectBlur) ppEffectAdjust [_blurFinal];
-    GVAR(ppeffectBlur) ppEffectCommit 0;
-    GVAR(ppeffectBlur) ppEffectForceInNVG true;
-    GVAR(ppeffectBlur) ppEffectEnable true;
-
-
-    // Modify local fog:
-    if (GVAR(fogScaling) > 0) then {
-        private _vehicle = vehicle _unit;
-
-        if (_vehicle != _unit && {_vehicle isKindOf "Air"}) then {  // For flying in particular, can refine nicer later.
-            _fogApply = _fogApply * ST_NVG_AIR_FOG_MULTIPLIER;
-        };
-
-        _fogApply = linearConversion [0, 1, GVAR(priorFog) select 0, (GVAR(fogScaling) * _fogApply), 1]; // mix in old fog if present
-        GVAR(nvgFog) = fogParams;
-        GVAR(nvgFog) set [0, _fogApply];
-
-        0 setFog GVAR(nvgFog)
-    };
 
     #ifdef DEBUG_MODE_FULL
     private _aceAmbient = [] call EFUNC(common,ambientBrightness);

--- a/addons/nightvision/stringtable.xml
+++ b/addons/nightvision/stringtable.xml
@@ -519,6 +519,21 @@
             <Chinesesimp>夜视仪（宽，绿色, 白磷）</Chinesesimp>
             <Ukrainian>ПНБ (Широкий, Зелений, БФ)</Ukrainian>
         </Key>
+        <Key ID="STR_ACE_NightVision_H_PilotHelmetFighter_B_WP">
+            <English>Pilot Helmet [NATO, WP]</English>
+        </Key>
+        <Key ID="STR_ACE_NightVision_H_PilotHelmetFighter_I_WP">
+            <English>Pilot Helmet [AAF, WP]</English>
+        </Key>
+        <Key ID="STR_ACE_NightVision_H_PilotHelmetFighter_O_WP">
+            <English>Pilot Helmet [CSAT, WP]</English>
+        </Key>
+        <Key ID="STR_ACE_NightVision_H_HelmetO_ViperSP_hex_WP">
+            <English>Special Purpose Helmet (Hex, WP)</English>
+        </Key>
+        <Key ID="STR_ACE_NightVision_H_HelmetO_ViperSP_ghex_WP">
+            <English>Special Purpose Helmet (Green Hex, WP)</English>
+        </Key>
         <Key ID="STR_ACE_NightVision_NVGeneration">
             <English>Night Vision Generation</English>
             <French>Génération de jumelles de vision nocturne</French>


### PR DESCRIPTION
**When merged this pull request will:**
- Add a secondary check to fnc_onSlotItemChanged and the "unit" playerEventHandler in XEH_postInit for headgear integrated night vision.
- Changes fnc_pfeh to prevent non-color effects applying for nvg generation -1.
- Adds config to remove border from integrated nvg classes and set them to gen -1.
- Adds WP variants of pilot and special purpose helmets that use integrated night vision.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
