### PR TITLE
Docs - Remove warning about BIS event handlers

### DIFF
--- a/docs/wiki/development/coding-guidelines.md
+++ b/docs/wiki/development/coding-guidelines.md
@@ -90,7 +90,7 @@ There also exists the `FUNC` family of Macros:
 |`EFUNC(leg,face)` | `ace_leg_fnc_face` or the call trace wrapper for that function. |
 |`DFUNC(face)` | `ace_balls_fnc_face` and will ALWAYS be the function global variable. |
 |`DEFUNC(leg,face)` | `ace_leg_fnc_face` and will ALWAYS be the function global variable. |
-|`LINKFUNC(face)` | `FUNC(face)` or "pass by reference" `{_this call FUNC(face)}` |
+|`LINKFUNC(face)` | `FUNC(face)` or "pass by reference" `{call FUNC(face)}` |
 |`QFUNC(face)` | `"ace_balls_fnc_face"` |
 |`QEFUNC(leg,face)` | `"ace_leg_fnc_face"` |
 |`QQFUNC(face)` | `""ace_balls_fnc_face""` used inside `QUOTE` macros where double quotation is required.  |
@@ -639,13 +639,6 @@ All ACE3 components shall be implemented in an event driven fashion. This is don
 Event handlers in ACE3 are implemented through the CBA event system (ACE3's own event system is deprecated since 3.6.0). They should be used to trigger or allow triggering of specific functionality.
 
 More information on the [CBA Events System](https://github.com/CBATeam/CBA_A3/wiki/Custom-Events-System){:target="_blank"} and [CBA Player Events](https://github.com/CBATeam/CBA_A3/wiki/Player-Events){:target="_blank"} pages.
-
-**Warning about BIS event handlers:**
-BIS's event handlers (`addEventHandler`, `addMissionEventHandler`) are slow when passing a large code variable. Use a short code block that calls the function you want.
-```sqf
-player addEventHandler ["Fired", FUNC(handleFired)]; // bad
-player addEventHandler ["Fired", {call FUNC(handleFired)}]; // good
-```
 
 ## 8. Performance Considerations
 


### PR DESCRIPTION
**When merged this pull request will:**
- remove warning about BIS event handlers (added in #4898);
- remove `_this` from `LINKFUNC` description (removed in #10735).

I found `Tweaked: Mission / Object Event Handlers are no longer recompiled when added` line in [2.08 changelog](https://dev.arma3.com/post/spotrep-00102).

Test 1:
```
addMissionEventHandler ["Draw3D", {x3 = diag_tickTime}];
for "_index" from 1 to 2000 do {
    // addMissionEventHandler ["Draw3D", ace_interact_menu_fnc_render]; // 237 ms menu=1
    addMissionEventHandler ["Draw3D", {call ace_interact_menu_fnc_render}]; // 237 ms menu=1
};
addMissionEventHandler ["Draw3D", {
    if (ace_interact_menu_openedMenuType>=0) then {
        diag_log text format ["2000 calls took %1 ms menu=%2", 1000 * (diag_tickTime - x3), ace_interact_menu_openedMenuType]
    };
}];
```
Both cases shows the same result.

Test 2:
```
player addEventHandler ["Fired", {x3 = diag_tickTime}];
for "_index" from 1 to 200000 do {
    // player addEventHandler ["Fired", ace_interact_menu_fnc_render]; // 421.875 ms
    player addEventHandler ["Fired", {call ace_interact_menu_fnc_render}]; // 445.313 ms
};
player addEventHandler ["Fired", {diag_log text format ["200000 calls took %1 ms", 1000 * (diag_tickTime - x3)]}];
```
`render` does nothing while firing so I increased iteration number. `{call}` is even slower.