### PR TITLE
Explosives - Fix explosives crate inventories

### DIFF
--- a/addons/explosives/CfgVehicles.hpp
+++ b/addons/explosives/CfgVehicles.hpp
@@ -207,9 +207,9 @@ class CfgVehicles {
     class NATO_Box_Base;
     class EAST_Box_Base;
     class IND_Box_Base;
-    class ReammoBox_F;
     class FIA_Box_Base_F;
     class Box_NATO_Support_F;
+    class ReammoBox_F;
 
     class Box_NATO_AmmoOrd_F: NATO_Box_Base {
         class TransportItems {
@@ -243,16 +243,17 @@ class CfgVehicles {
         };
     };
 
+    class Box_IDAP_AmmoOrd_F: Box_IND_AmmoOrd_F {
+        class TransportItems {
+            MACRO_ADDITEM(ACE_Clacker,2);
+            MACRO_ADDITEM(ACE_DefusalKit,2);
+        };
+    };
+
     class Box_IED_Exp_F: ReammoBox_F {
         class TransportItems {
             MACRO_ADDITEM(ACE_Deadmanswitch,6);
             MACRO_ADDITEM(ACE_Cellphone,3);
-        };
-    };
-
-    class Box_IDAP_AmmoOrd_F: Box_IND_AmmoOrd_F {
-        class TransportItems {
-            MACRO_ADDITEM(ACE_Clacker,2);
         };
     };
 

--- a/addons/explosives/CfgVehicles.hpp
+++ b/addons/explosives/CfgVehicles.hpp
@@ -207,6 +207,7 @@ class CfgVehicles {
     class NATO_Box_Base;
     class EAST_Box_Base;
     class IND_Box_Base;
+    class ReammoBox_F;
     class FIA_Box_Base_F;
     class Box_NATO_Support_F;
 
@@ -231,8 +232,27 @@ class CfgVehicles {
             MACRO_ADDITEM(ACE_Clacker,12);
             MACRO_ADDITEM(ACE_M26_Clacker,6);
             MACRO_ADDITEM(ACE_DefusalKit,12);
-            MACRO_ADDITEM(ACE_Deadmanswitch,2);
+        };
+    };
+
+    class Box_EAF_AmmoOrd_F: Box_IND_AmmoOrd_F {
+        class TransportItems {
+            MACRO_ADDITEM(ACE_Clacker,12);
+            MACRO_ADDITEM(ACE_M26_Clacker,6);
+            MACRO_ADDITEM(ACE_DefusalKit,12);
+        };
+    };
+
+    class Box_IED_Exp_F: ReammoBox_F {
+        class TransportItems {
+            MACRO_ADDITEM(ACE_Deadmanswitch,6);
             MACRO_ADDITEM(ACE_Cellphone,3);
+        };
+    };
+
+    class Box_IDAP_AmmoOrd_F: Box_IND_AmmoOrd_F {
+        class TransportItems {
+            MACRO_ADDITEM(ACE_Clacker,2);
         };
     };
 


### PR DESCRIPTION
**When merged this pull request will:**
- Add the missing ACE detonators and defusal kits to the LDF explosives crate;
- Add cellphones and dead man switches to the IED explosives crate;
- Add two M57 clackers to the IDAP explosives crate;
- Remove the misplaced IED detonators from the AAF explosives crate.

Each crate now has the equipment it should

Fixes [#11394](https://github.com/acemod/ACE3/issues/11394)
