### PR TITLE
Mk6 Mortar - Fix fire-on-load ballistics

### DIFF
--- a/addons/artillerytables/functions/fnc_firedEH.sqf
+++ b/addons/artillerytables/functions/fnc_firedEH.sqf
@@ -25,7 +25,7 @@
 params ["_vehicle", "", "", "", "", "_magazine", "_projectile", "_gunner"];
 TRACE_4("firedEH",_vehicle,_magazine,_projectile,_gunner);
 
-if !(_gunner call EFUNC(common,isPlayer) && { !(_gunner getVariable [QEGVAR(csw,isProxy), false]) }) exitWith {}; // AI don't know how to use (this does give them more range than a player)
+if (!(_gunner call EFUNC(common,isPlayer)) && { !(_gunner getVariable [QEGVAR(csw,autofire_isProxy), false]) }) exitWith {}; // AI don't know how to use (this does give them more range than a player)
 if ((gunner _vehicle) != _gunner) exitWith {}; // check if primaryGunner
 
 

--- a/addons/mk6mortar/functions/fnc_handleFired.sqf
+++ b/addons/mk6mortar/functions/fnc_handleFired.sqf
@@ -28,7 +28,7 @@ if (_vehicle distance ACE_player > 8000) exitWith {};
 
 //AI will have no clue how to use:
 private _shooterMan = gunner _vehicle;
-if (!(_shooterMan call EFUNC(common,isPlayer)) && { !(_shooterMan getVariable [QEGVAR(csw,isProxy), false]) }) exitWith {};
+if (!(_shooterMan call EFUNC(common,isPlayer)) && { !(_shooterMan getVariable [QEGVAR(csw,autofire_isProxy), false]) }) exitWith {};
 
 
 //Calculate air density:


### PR DESCRIPTION
**When merged this pull request will:**
- Apply air resistance and advanced artillery corrections to rounds fired automatically on load.

proxy gunner was treated as regular AI, skipping ballistic corrections.

Fixes [#11260](https://github.com/acemod/ACE3/issues/11260)