### PR TITLE
Vehicle Damage - Fix Slammer optic cookoff

### DIFF
--- a/addons/vehicle_damage/CfgVehicles.hpp
+++ b/addons/vehicle_damage/CfgVehicles.hpp
@@ -140,7 +140,6 @@ class CfgVehicles {
     };
     class B_MBT_01_base_F: MBT_01_base_F {};
     class B_MBT_01_cannon_F: B_MBT_01_base_F {
-        GVAR(hitpointAlias)[] = {{"gun", {"HitComTurret"}}};
         GVAR(turret)[] = { QGVAR(Turret_MBT_01), {0, -1, 0.5} };
     };
     class B_MBT_01_TUSK_F: B_MBT_01_cannon_F {

--- a/addons/vehicle_damage/CfgVehicles.hpp
+++ b/addons/vehicle_damage/CfgVehicles.hpp
@@ -140,6 +140,7 @@ class CfgVehicles {
     };
     class B_MBT_01_base_F: MBT_01_base_F {};
     class B_MBT_01_cannon_F: B_MBT_01_base_F {
+        GVAR(hitpointAlias)[] = {{"gun", {"HitComTurret"}}};
         GVAR(turret)[] = { QGVAR(Turret_MBT_01), {0, -1, 0.5} };
     };
     class B_MBT_01_TUSK_F: B_MBT_01_cannon_F {

--- a/addons/vehicle_damage/functions/fnc_addEventHandler.sqf
+++ b/addons/vehicle_damage/functions/fnc_addEventHandler.sqf
@@ -48,6 +48,7 @@ private _typeOf = typeOf _vehicle;
 if (_typeOf in GVAR(vehicleClassesHitPointHash)) exitWith {};
 
 private _hitPointHash = createHashMap;
+private _ambiguousHitpoints = [];
 private _vehicleConfig = configOf _vehicle;
 private _hitPointsConfig = _vehicleConfig >> "HitPoints";
 
@@ -62,7 +63,7 @@ private _hitPointsConfig = _vehicleConfig >> "HitPoints";
 
 // Gun and turret hitpoints aren't hardcoded anymore - dig through config to find correct names
 private _fnc_iterateThroughConfig = {
-    params ["_config"];
+    params ["_config", ["_turretPath", false, [[], false]]];
     TRACE_1("checking config",_config);
 
     private _configName = toLowerANSI configName _config;
@@ -91,28 +92,39 @@ private _fnc_iterateThroughConfig = {
     } forEach _hitPointAliases;
 
     if (_isGun || _isTurret || _isEra || _isSlat || _isMisc) then {
-        if (!_isMisc && _isGun) then {
+        if (_isGun) then {
             _hitPointHash set [_configName, ["gun", abs getNumber (_config >> "minimalHit")]];
         };
-        if (!_isMisc && _isTurret) then {
-            _hitPointHash set [_configName, ["turret", abs getNumber (_config >> "minimalHit")]];
+        if (_isTurret) then {
+            private _hitPointData = ["turret", abs getNumber (_config >> "minimalHit")];
+
+            if (_turretPath isEqualType [] && {!(_configName in _ambiguousHitpoints)}) then {
+                private _existingTurretPath = (_hitPointHash getOrDefault [_configName, []]) param [2, false, [[], false]];
+
+                if (_existingTurretPath isEqualType [] && {_existingTurretPath isNotEqualTo _turretPath}) then {
+                    _ambiguousHitpoints pushBack _configName;
+                } else {
+                    _hitPointData pushBack _turretPath;
+                };
+            };
+
+            _hitPointHash set [_configName, _hitPointData];
         };
-        if (!_isMisc && _isEra) then {
+        if (_isEra) then {
             _hitPointHash set [_configName, ["era", abs getNumber (_config >> "minimalHit")]];
         };
-        if (!_isMisc && _isSlat) then {
+        if (_isSlat) then {
             _hitPointHash set [_configName, ["slat", abs getNumber (_config >> "minimalHit")]];
         };
 
         TRACE_6("found gun/turret/era/slat/misc",_isGun,_isTurret,_isEra,_isSlat,_isMisc,_hitPointHash);
     } else {
         {
-            _x call _fnc_iterateThroughConfig;
+            [_x, _turretPath] call _fnc_iterateThroughConfig;
         } forEach configProperties [_config, "isClass _x", true];
     };
 };
 
-private _turretConfig = _vehicleConfig >> "Turrets";
 private _eraHitpoints = (getArray (_vehicleConfig >> QGVAR(eraHitpoints))) apply {toLowerANSI _x};
 private _slatHitpoints = (getArray (_vehicleConfig >> QGVAR(slatHitpoints))) apply {toLowerANSI _x};
 
@@ -132,7 +144,11 @@ private _hitPointAliases = (getArray (_vehicleConfig >> QGVAR(hitpointAlias))) c
 TRACE_1("hitpoint alias",_hitPointAliases);
 
 _hitPointsConfig call _fnc_iterateThroughConfig;
-_turretConfig call _fnc_iterateThroughConfig;
+
+{
+    private _turretConfig = [_vehicleConfig, _x] call EFUNC(common,getTurretConfigPath);
+    [_turretConfig >> "HitPoints", _x] call _fnc_iterateThroughConfig;
+} forEach allTurrets [_vehicle, true];
 
 GVAR(vehicleClassesHitPointHash) set [_typeOf, _hitPointHash];
 

--- a/addons/vehicle_damage/functions/fnc_addEventHandler.sqf
+++ b/addons/vehicle_damage/functions/fnc_addEventHandler.sqf
@@ -91,16 +91,16 @@ private _fnc_iterateThroughConfig = {
     } forEach _hitPointAliases;
 
     if (_isGun || _isTurret || _isEra || _isSlat || _isMisc) then {
-        if (_isGun) then {
+        if (!_isMisc && _isGun) then {
             _hitPointHash set [_configName, ["gun", abs getNumber (_config >> "minimalHit")]];
         };
-        if (_isTurret) then {
+        if (!_isMisc && _isTurret) then {
             _hitPointHash set [_configName, ["turret", abs getNumber (_config >> "minimalHit")]];
         };
-        if (_isEra) then {
+        if (!_isMisc && _isEra) then {
             _hitPointHash set [_configName, ["era", abs getNumber (_config >> "minimalHit")]];
         };
-        if (_isSlat) then {
+        if (!_isMisc && _isSlat) then {
             _hitPointHash set [_configName, ["slat", abs getNumber (_config >> "minimalHit")]];
         };
 

--- a/addons/vehicle_damage/functions/fnc_processHit.sqf
+++ b/addons/vehicle_damage/functions/fnc_processHit.sqf
@@ -52,7 +52,7 @@ private _warheadType = ["he", "ap", "heat", "tandemheat"] find _warheadTypeStr; 
 private _incendiary = [_projectileConfig >> QGVAR(incendiary), "NUMBER", [0.3, 0.1, 1, 1, 0] select _warheadType] call CBA_fnc_getConfigEntry;
 
 private _hitPointHash = GVAR(vehicleClassesHitPointHash) getOrDefault [typeOf _vehicle, createHashMap];
-(_hitPointHash getOrDefault [_hitPoint, []]) params ["_hitArea", "_minDamage"];
+(_hitPointHash getOrDefault [_hitPoint, []]) params ["_hitArea", "_minDamage", ["_turretPath", false, [[], false]]];
 
 private _projectileExplosive = getNumber (_projectileConfig >> "explosive");
 private _indirectHit = getNumber (_projectileConfig >> "indirectHit");
@@ -151,6 +151,11 @@ if (_magazines isNotEqualTo []) then {
 };
 
 private _return = true;
+
+// Secondary turrets are non-lethal
+if (_hitArea == "turret" && {_turretPath isEqualType [] && {_turretPath isNotEqualTo [0]}}) then {
+    _hitArea = "gun";
+};
 
 switch (_hitArea) do {
     case "engine": {


### PR DESCRIPTION
**When merged this pull request will:**
- Prevent damage to the Slammer commander optics from causing ammunition cook-off.

commander optics were incorrectly classified as the main turret

Fixes [#11311](https://github.com/acemod/ACE3/issues/11311)

<img width="1299" height="730" alt="image" src="https://github.com/user-attachments/assets/76b8e8f1-299c-420a-9413-6ef674c90721" />

