### PR TITLE
Volume - Make volume reduction of music independent from sound effects.

### DIFF
--- a/addons/volume/ACE_Settings.hpp
+++ b/addons/volume/ACE_Settings.hpp
@@ -2,7 +2,10 @@ class ACE_Settings {
     class XGVAR(enabled) {
         movedToSQF = 1;
     };
-    class XGVAR(reduction) {
+    class XGVAR(reduction_sound) {
+        movedToSQF = 1;
+    };
+    class XGVAR(reduction_music) {
         movedToSQF = 1;
     };
     class XGVAR(fadeDelay) {

--- a/addons/volume/ACE_Settings.hpp
+++ b/addons/volume/ACE_Settings.hpp
@@ -2,10 +2,10 @@ class ACE_Settings {
     class XGVAR(enabled) {
         movedToSQF = 1;
     };
-    class XGVAR(reduction_sound) {
+    class XGVAR(reduction) {
         movedToSQF = 1;
     };
-    class XGVAR(reduction_music) {
+    class XGVAR(reductionMusic) {
         movedToSQF = 1;
     };
     class XGVAR(fadeDelay) {

--- a/addons/volume/ACE_Settings.hpp
+++ b/addons/volume/ACE_Settings.hpp
@@ -5,9 +5,6 @@ class ACE_Settings {
     class XGVAR(reduction) {
         movedToSQF = 1;
     };
-    class XGVAR(reductionMusic) {
-        movedToSQF = 1;
-    };
     class XGVAR(fadeDelay) {
         movedToSQF = 1;
     };

--- a/addons/volume/functions/fnc_lowerVolume.sqf
+++ b/addons/volume/functions/fnc_lowerVolume.sqf
@@ -17,11 +17,11 @@
 
 EGVAR(hearing,disableVolumeUpdate) = true;
 
-private _coef_sound = XGVAR(reduction_sound) / 10;
-private _coef_music = XGVAR(reduction_music) / 10;
+private _coefSound = XGVAR(reduction) / 10;
+private _coefMusic = XGVAR(reductionMusic) / 10;
 
-private _reductionGame = _coef_sound * GVAR(initialGameVolume);
-private _reductionMusic = _coef_music * GVAR(initialMusicVolume);
+private _reductionGame = _coefSound * GVAR(initialGameVolume);
+private _reductionMusic = _coefMusic * GVAR(initialMusicVolume);
 
 
 

--- a/addons/volume/functions/fnc_lowerVolume.sqf
+++ b/addons/volume/functions/fnc_lowerVolume.sqf
@@ -23,9 +23,6 @@ private _coefMusic = XGVAR(reductionMusic) / 10;
 private _reductionGame = _coefSound * GVAR(initialGameVolume);
 private _reductionMusic = _coefMusic * GVAR(initialMusicVolume);
 
-
-
-
 XGVAR(fadeDelay) fadeSound (GVAR(initialGameVolume) - _reductionGame);
 XGVAR(fadeDelay) fadeMusic (GVAR(initialMusicVolume) - _reductionMusic);
 

--- a/addons/volume/functions/fnc_lowerVolume.sqf
+++ b/addons/volume/functions/fnc_lowerVolume.sqf
@@ -17,9 +17,14 @@
 
 EGVAR(hearing,disableVolumeUpdate) = true;
 
-private _coef = XGVAR(reduction) / 10;
-private _reductionGame = _coef * GVAR(initialGameVolume);
-private _reductionMusic = _coef * GVAR(initialMusicVolume);
+private _coef_sound = XGVAR(reduction_sound) / 10;
+private _coef_music = XGVAR(reduction_music) / 10;
+
+private _reductionGame = _coef_sound * GVAR(initialGameVolume);
+private _reductionMusic = _coef_music * GVAR(initialMusicVolume);
+
+
+
 
 XGVAR(fadeDelay) fadeSound (GVAR(initialGameVolume) - _reductionGame);
 XGVAR(fadeDelay) fadeMusic (GVAR(initialMusicVolume) - _reductionMusic);

--- a/addons/volume/initSettings.inc.sqf
+++ b/addons/volume/initSettings.inc.sqf
@@ -7,9 +7,17 @@
 ] call CBA_fnc_addSetting;
 
 [
-    QXGVAR(reduction),
+    QXGVAR(reduction_sound),
     "LIST",
-    [LSTRING(Reduction), LSTRING(ReductionDescription)],
+    [LSTRING(ReductionSound), LSTRING(ReductionDescriptionSound)],
+    format ["ACE %1", LLSTRING(Name)],
+    [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], ["0%", "10%", "20%", "30%", "40%", "50%", "60%", "70%", "80%", "90%", "100%"], 5]
+] call CBA_fnc_addSetting;
+
+[
+    QXGVAR(reduction_music),
+    "LIST",
+    [LSTRING(ReductionMusic), LSTRING(ReductionDescriptionMusic)],
     format ["ACE %1", LLSTRING(Name)],
     [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], ["0%", "10%", "20%", "30%", "40%", "50%", "60%", "70%", "80%", "90%", "100%"], 5]
 ] call CBA_fnc_addSetting;

--- a/addons/volume/initSettings.inc.sqf
+++ b/addons/volume/initSettings.inc.sqf
@@ -7,7 +7,7 @@
 ] call CBA_fnc_addSetting;
 
 [
-    QXGVAR(reduction_sound),
+    QXGVAR(reduction),
     "LIST",
     [LSTRING(ReductionSound), LSTRING(ReductionDescriptionSound)],
     format ["ACE %1", LLSTRING(Name)],
@@ -15,7 +15,7 @@
 ] call CBA_fnc_addSetting;
 
 [
-    QXGVAR(reduction_music),
+    QXGVAR(reductionMusic),
     "LIST",
     [LSTRING(ReductionMusic), LSTRING(ReductionDescriptionMusic)],
     format ["ACE %1", LLSTRING(Name)],

--- a/addons/volume/stringtable.xml
+++ b/addons/volume/stringtable.xml
@@ -144,7 +144,7 @@
             <Ukrainian>Гучність</Ukrainian>
         </Key>
         <Key ID="STR_ACE_Volume_ReductionSound">
-            <English>Reduction</English>
+            <English>Reduction (Sound Effects)</English>
             <French>Réduction</French>
             <Spanish>Reducción</Spanish>
             <Italian>Riduzione</Italian>
@@ -190,18 +190,6 @@
         </Key>
         <Key ID="STR_ACE_Volume_ReductionDescriptionMusic">
             <English>Reduce volume by this percentage.</English>
-            <French>Réduit le volume de ce pourcentage.</French>
-            <Spanish>Reducir el volumen este porcentaje.</Spanish>
-            <Italian>Riduci il volume di questa percentuale.</Italian>
-            <Polish>Zmniejsz głosność o tyle procent</Polish>
-            <Portuguese>Reduzir o volume por esta porcentagem.</Portuguese>
-            <Russian>Уменьшает громкость</Russian>
-            <German>Reduziere Lautstärke um diesen Prozentsatz.</German>
-            <Korean>다음의 비율로 음량을 감소합니다.</Korean>
-            <Japanese>この割合で音量を低減します。</Japanese>
-            <Chinese>使用此百分比來調整音量降低大小。</Chinese>
-            <Chinesesimp>使用此百分比来调整音量降低大小。</Chinesesimp>
-            <Ukrainian>Зменшує гучність</Ukrainian>
         </Key>
         <Key ID="STR_ACE_Volume_RemindIfLowered">
             <English>Reminder if lowered</English>

--- a/addons/volume/stringtable.xml
+++ b/addons/volume/stringtable.xml
@@ -173,7 +173,7 @@
             <Chinesesimp>使用此百分比来调整音量降低大小。</Chinesesimp>
             <Ukrainian>Зменшує гучність</Ukrainian>
         </Key>
-            <Key ID="STR_ACE_Volume_ReductionMusic">
+        <Key ID="STR_ACE_Volume_ReductionMusic">
             <English>Reduction (Music)</English>
             <French>Réduction (Musique)</French>
             <Spanish>Reducción (Música)</Spanish>

--- a/addons/volume/stringtable.xml
+++ b/addons/volume/stringtable.xml
@@ -144,7 +144,7 @@
             <Ukrainian>Гучність</Ukrainian>
         </Key>
         <Key ID="STR_ACE_Volume_ReductionSound">
-            <English>Reduction of sound effects</English>
+            <English>Reduction</English>
             <French>Réduction</French>
             <Spanish>Reducción</Spanish>
             <Italian>Riduzione</Italian>
@@ -159,7 +159,7 @@
             <Ukrainian>Зменшення</Ukrainian>
         </Key>
         <Key ID="STR_ACE_Volume_ReductionDescriptionSound">
-            <English>Reduce sound effects volume by this percentage.</English>
+            <English>Reduce volume by this percentage.</English>
             <French>Réduit le volume de ce pourcentage.</French>
             <Spanish>Reducir el volumen este porcentaje.</Spanish>
             <Italian>Riduci il volume di questa percentuale.</Italian>
@@ -174,22 +174,22 @@
             <Ukrainian>Зменшує гучність</Ukrainian>
         </Key>
             <Key ID="STR_ACE_Volume_ReductionMusic">
-            <English>Reduction of music</English>
-            <French>Réduction</French>
-            <Spanish>Reducción</Spanish>
-            <Italian>Riduzione</Italian>
-            <Polish>Redukcja</Polish>
-            <Portuguese>Redução</Portuguese>
-            <Russian>Уменьшение</Russian>
-            <German>Reduzierung</German>
-            <Korean>감소</Korean>
-            <Japanese>低減</Japanese>
-            <Chinese>降低</Chinese>
-            <Chinesesimp>降低</Chinesesimp>
-            <Ukrainian>Зменшення</Ukrainian>
+            <English>Reduction (Music)</English>
+            <French>Réduction (Musique)</French>
+            <Spanish>Reducción (Música)</Spanish>
+            <Italian>Riduzione (Musica)</Italian>
+            <Polish>Redukcja (Muzyka)</Polish>
+            <Portuguese>Redução (Música)</Portuguese>
+            <Russian>Уменьшение (Музыка)</Russian>
+            <German>Reduzierung (Musik)</German>
+            <Korean>감소 (음악)</Korean>
+            <Japanese>低減 (BGM)</Japanese>
+            <Chinese>降低 (音樂)</Chinese>
+            <Chinesesimp>降低 (音乐)</Chinesesimp>
+            <Ukrainian>Зменшення (музика)</Ukrainian>
         </Key>
         <Key ID="STR_ACE_Volume_ReductionDescriptionMusic">
-            <English>Reduce music volume by this percentage.</English>
+            <English>Reduce volume by this percentage.</English>
             <French>Réduit le volume de ce pourcentage.</French>
             <Spanish>Reducir el volumen este porcentaje.</Spanish>
             <Italian>Riduci il volume di questa percentuale.</Italian>

--- a/addons/volume/stringtable.xml
+++ b/addons/volume/stringtable.xml
@@ -143,8 +143,8 @@
             <Turkish>Ses</Turkish>
             <Ukrainian>Гучність</Ukrainian>
         </Key>
-        <Key ID="STR_ACE_Volume_Reduction">
-            <English>Reduction</English>
+        <Key ID="STR_ACE_Volume_ReductionSound">
+            <English>Reduction of sound effects</English>
             <French>Réduction</French>
             <Spanish>Reducción</Spanish>
             <Italian>Riduzione</Italian>
@@ -158,8 +158,38 @@
             <Chinesesimp>降低</Chinesesimp>
             <Ukrainian>Зменшення</Ukrainian>
         </Key>
-        <Key ID="STR_ACE_Volume_ReductionDescription">
-            <English>Reduce volume by this percentage.</English>
+        <Key ID="STR_ACE_Volume_ReductionDescriptionSound">
+            <English>Reduce sound effects volume by this percentage.</English>
+            <French>Réduit le volume de ce pourcentage.</French>
+            <Spanish>Reducir el volumen este porcentaje.</Spanish>
+            <Italian>Riduci il volume di questa percentuale.</Italian>
+            <Polish>Zmniejsz głosność o tyle procent</Polish>
+            <Portuguese>Reduzir o volume por esta porcentagem.</Portuguese>
+            <Russian>Уменьшает громкость</Russian>
+            <German>Reduziere Lautstärke um diesen Prozentsatz.</German>
+            <Korean>다음의 비율로 음량을 감소합니다.</Korean>
+            <Japanese>この割合で音量を低減します。</Japanese>
+            <Chinese>使用此百分比來調整音量降低大小。</Chinese>
+            <Chinesesimp>使用此百分比来调整音量降低大小。</Chinesesimp>
+            <Ukrainian>Зменшує гучність</Ukrainian>
+        </Key>
+            <Key ID="STR_ACE_Volume_ReductionMusic">
+            <English>Reduction of music</English>
+            <French>Réduction</French>
+            <Spanish>Reducción</Spanish>
+            <Italian>Riduzione</Italian>
+            <Polish>Redukcja</Polish>
+            <Portuguese>Redução</Portuguese>
+            <Russian>Уменьшение</Russian>
+            <German>Reduzierung</German>
+            <Korean>감소</Korean>
+            <Japanese>低減</Japanese>
+            <Chinese>降低</Chinese>
+            <Chinesesimp>降低</Chinesesimp>
+            <Ukrainian>Зменшення</Ukrainian>
+        </Key>
+        <Key ID="STR_ACE_Volume_ReductionDescriptionMusic">
+            <English>Reduce music volume by this percentage.</English>
             <French>Réduit le volume de ce pourcentage.</French>
             <Spanish>Reducir el volumen este porcentaje.</Spanish>
             <Italian>Riduci il volume di questa percentuale.</Italian>

--- a/docs/wiki/feature/volume.md
+++ b/docs/wiki/feature/volume.md
@@ -21,7 +21,7 @@ Adds the possibility of setting a keybind to toggle volume of game and music. It
 ## 2. Features
 
 - Automatically lower volume when inside vehicles (restores when exiting vehicles)
-- Change reduction percentage and fade delay
+- Change reduction percentage of both sound effects and music as well as fade delay
 - Option to show/hide notification
 - Option to remind you every minute if your volume is lowered
 


### PR DESCRIPTION
**When merged this pull request will:**
- Separates music and sound effect reduction
- Adds an additional drop down box to choose the reduction percentage of music

One of the suggested use cases of ace volume is for when operating loud vehicles and it's slightly annoyed me that the volume of whatever music is playing will be lowered by the same amount as the sound effects, this rectifies this by adding the option to choose the music reduction percentage independently.

I have read all of the guidance related to contributing however I have not been able to locate any guidance that relates to when you have made a translation redundant, what am I supposed to do there?