### PR TITLE
Medical - Fix blood spurts from discarded damage

### DIFF
--- a/addons/medical_blood/functions/fnc_handleWoundReceived.sqf
+++ b/addons/medical_blood/functions/fnc_handleWoundReceived.sqf
@@ -5,7 +5,7 @@
  *
  * Arguments:
  * 0: Unit <OBJECT>
- * 1: Damage done to each body part <ARRAY>
+ * 1: Damage <NUMBER or ARRAY>
  * 2: Shooter <OBJECT>
  * 3: Ammo classname or damage type <STRING>
  *
@@ -13,13 +13,18 @@
  * None
  *
  * Example:
- * [player, "Body", 0.5, badGuy] call ace_medical_blood_fnc_handleWoundReceived
+ * [player, 0.5, badGuy, "bullet"] call ace_medical_blood_fnc_handleWoundReceived
  *
  * Public: No
  */
 
-params ["_unit", "_allDamages", "_shooter", "_damageType"];
-(_allDamages select 0) params ["_damage"];
+params ["_unit", "_damage", "_shooter", "_damageType"];
+
+if (_damage isEqualTo []) exitWith {};
+
+if (_damage isEqualType []) then {
+    _damage = _damage select 0 select 0;
+};
 
 // Don't bleed if damage type does not cause bleeding
 if (_damageType in (uiNamespace getVariable QGVAR(noBloodDamageTypes))) exitWith {};

--- a/addons/medical_blood/functions/fnc_init.sqf
+++ b/addons/medical_blood/functions/fnc_init.sqf
@@ -18,6 +18,11 @@
 
 params ["_mode"];
 
+private _woundEvent = [
+    QEGVAR(medical,woundReceived),
+    QEGVAR(medical,woundProcessed)
+] select isClass (configFile >> "CfgPatches" >> "ace_medical_damage");
+
 // Exit if setting is refreshed to the same value
 if (!isNil QGVAR(currentSetup) && {_mode == GVAR(currentSetup)}) exitWith {
     TRACE_2("Setting refreshed to current setup",GVAR(currentSetup),_mode);
@@ -34,7 +39,7 @@ if (!isNil QGVAR(stateMachine)) then {
 
 // Remove wound received if it was previously added
 if (!isNil QGVAR(woundReceivedEH)) then {
-    [QEGVAR(medical,woundReceived), GVAR(woundReceivedEH)] call CBA_fnc_removeEventHandler;
+    [_woundEvent, GVAR(woundReceivedEH)] call CBA_fnc_removeEventHandler;
     GVAR(woundReceivedEH) = nil;
 };
 
@@ -60,6 +65,6 @@ private _listCode = if (_mode == BLOOD_ONLY_PLAYERS) then {
 GVAR(stateMachine) = [_listCode, true] call CBA_statemachine_fnc_create;
 [GVAR(stateMachine), LINKFUNC(onBleeding), {}, {}, "Bleeding"] call CBA_statemachine_fnc_addState;
 
-GVAR(woundReceivedEH) = [QEGVAR(medical,woundReceived), LINKFUNC(handleWoundReceived)] call CBA_fnc_addEventHandler;
+GVAR(woundReceivedEH) = [_woundEvent, LINKFUNC(handleWoundReceived)] call CBA_fnc_addEventHandler;
 
 TRACE_3("Set up state machine and wounds event",_mode,GVAR(stateMachine),GVAR(woundReceivedEH));

--- a/addons/medical_damage/functions/fnc_woundReceived.sqf
+++ b/addons/medical_damage/functions/fnc_woundReceived.sqf
@@ -27,6 +27,7 @@ if !(_typeOfDamage in GVAR(damageTypeDetails)) exitWith {};
 (GVAR(damageTypeDetails) get _typeOfDamage) params ["", "", "_woundHandlers"];
 if (_woundHandlers isEqualTo []) exitWith {};
 
+private _oldBodyPartDamage = +GET_BODYPART_DAMAGE(_unit);
 private _damageData = [_unit, _allDamages, _typeOfDamage, _ammo];
 private _originalCount = count _damageData;
 private _lastHandlerName = _woundHandlers select -1 select 0; // will usually be ace_medical_damage_woundsHandlerBase
@@ -53,3 +54,12 @@ private _lastHandlerName = _woundHandlers select -1 select 0; // will usually be
         break;
     };
 } forEach _woundHandlers;
+
+private _damage = 0;
+{
+    _damage = _damage max (_x - (_oldBodyPartDamage select _forEachIndex));
+} forEach GET_BODYPART_DAMAGE(_unit);
+
+if (_damage > 0) then {
+    [QEGVAR(medical,woundProcessed), [_unit, _damage, _shooter, _typeOfDamage]] call CBA_fnc_localEvent;
+};


### PR DESCRIPTION
**When merged this pull request will:**
- prevent blood spurts when wound handlers discard all damage.

blood spurts were created before wound handlers finished processing the damage.

Fixes [#11378](https://github.com/acemod/ACE3/issues/11378)
