### PR TITLE
CSW - Improve CSW tripod placement

### DIFF
--- a/addons/csw/CfgEventHandlers.hpp
+++ b/addons/csw/CfgEventHandlers.hpp
@@ -3,13 +3,21 @@ class Extended_PreStart_EventHandlers {
         init = QUOTE(call COMPILE_SCRIPT(XEH_preStart));
     };
 };
+
 class Extended_PreInit_EventHandlers {
     class ADDON {
         init = QUOTE(call COMPILE_SCRIPT(XEH_preInit));
     };
 };
+
 class Extended_PostInit_EventHandlers {
     class ADDON {
         init = QUOTE(call COMPILE_SCRIPT(XEH_postInit));
+    };
+};
+
+class Extended_DisplayLoad_EventHandlers {
+    class RscDisplayMission {
+        ADDON = QUOTE(call COMPILE_FILE(XEH_missionDisplayLoad));
     };
 };

--- a/addons/csw/CfgVehicles.hpp
+++ b/addons/csw/CfgVehicles.hpp
@@ -8,7 +8,7 @@ class CfgVehicles {
                 class GVAR(placeTripod) {
                     displayName = CSTRING(PlaceTripod_displayName);
                     condition = QUOTE(call FUNC(canDeployTripod));
-                    statement = QUOTE(call FUNC(assemble_deployTripod));
+                    statement = QUOTE(call FUNC(assemble_startDeployTripod));
                     exceptions[] = {};
                 };
             };

--- a/addons/csw/XEH_PREP.hpp
+++ b/addons/csw/XEH_PREP.hpp
@@ -24,10 +24,13 @@ PREP(assemble_deployWeapon);
 PREP(assemble_deployWeaponModifier);
 PREP(assemble_pickupTripod);
 PREP(assemble_pickupWeapon);
+PREP(assemble_startDeployTripod);
 
 PREP(canGetIn);
-
+PREP(deployCancel);
+PREP(deployConfirm);
 PREP(getCarryMagazine);
+PREP(handleScrollWheel);
 PREP(proxyWeapon);
 
 PREP(getLoadActions);

--- a/addons/csw/XEH_missionDisplayLoad.sqf
+++ b/addons/csw/XEH_missionDisplayLoad.sqf
@@ -1,0 +1,11 @@
+#include "script_component.hpp"
+
+params ["_display"];
+
+_display displayAddEventHandler ["MouseZChanged", {(_this select 1) call FUNC(handleScrollWheel)}];
+_display displayAddEventHandler ["MouseButtonDown", {
+    // Right clicking cancels deployment
+    if ((_this select 1) == 1 && {ACE_player getVariable [QGVAR(isDeploying), false]}) then {
+        GVAR(placeAction) = PLACE_CANCEL;
+    };
+}];

--- a/addons/csw/XEH_postInit.sqf
+++ b/addons/csw/XEH_postInit.sqf
@@ -1,6 +1,7 @@
 #include "script_component.hpp"
 
 GVAR(vehicleMagCache) = createHashMap;
+GVAR(deployPFH) = -1;
 
 ["CBA_settingsInitialized", {
     TRACE_3("settingsInit",GVAR(defaultAssemblyMode),GVAR(handleExtraMagazines),GVAR(ammoHandling));
@@ -42,6 +43,21 @@ GVAR(vehicleMagCache) = createHashMap;
 [QGVAR(returnAmmo), LINKFUNC(reload_handleReturnAmmo)] call CBA_fnc_addEventHandler;
 [QGVAR(autofire_fire), LINKFUNC(autofire_fire)] call CBA_fnc_addEventHandler;
 
+// Cancel placement if interact menu open
+["ace_interactMenuOpened", {
+    if (GVAR(deployPFH) != -1) then {
+        GVAR(placeAction) = PLACE_CANCEL;
+    };
+}] call CBA_fnc_addEventHandler;
+
+// When changing cameras, drop deploying CSWs
+["featureCamera", {
+    if ((_this select 1) == "") exitWith {};
+
+    if (GVAR(deployPFH) != -1) then {
+        GVAR(placeAction) = PLACE_CANCEL;
+    };
+}] call CBA_fnc_addPlayerEventHandler;
 
 #ifdef DEBUG_MODE_FULL
 call compile preprocessFileLineNumbers QPATHTOF(dev\checkStaticWeapons.sqf);

--- a/addons/csw/functions/fnc_assemble_deployTripod.sqf
+++ b/addons/csw/functions/fnc_assemble_deployTripod.sqf
@@ -1,100 +1,96 @@
 #include "..\script_component.hpp"
 /*
- * Author: tcvm
+ * Author: tcvm, johnb43
  * Deploys the tripod.
  *
  * Arguments:
  * 0: Unit <OBJECT>
+ * 1: Position ASL <ARRAY>
+ * 2: Vector direction & up <NUMBER>
  *
  * Return Value:
  * None
  *
  * Example:
- * player call ace_csw_fnc_assemble_deployTripod
+ * [player, (getPosASL player) vectorAdd [0, 2, 0], [[1, 0, 0], [0, 0, 1]]] call ace_csw_fnc_assemble_deployTripod
  *
  * Public: No
  */
 
-[{
-    params ["_player"];
-    TRACE_1("assemble_deployTripod",_player);
+params ["_player", "_posASL", "_vectorDirAndUp"];
+TRACE_1("assemble_deployTripod",_player);
 
-    // Save magazines and attachments (handle loaded launchers which can become csw like CUP Metis)
-    private _secondaryWeaponInfo = (getUnitLoadout _player) select 1;
-    private _secondaryWeaponClassname = _secondaryWeaponInfo deleteAt 0;
+// Save magazines and attachments (handle loaded launchers which can become csw like CUP Metis)
+private _secondaryWeaponInfo = (getUnitLoadout _player) select 1;
+private _secondaryWeaponClassname = _secondaryWeaponInfo deleteAt 0;
 
-    // Remove empty entries
-    _secondaryWeaponInfo = _secondaryWeaponInfo select {_x isNotEqualTo "" && {_x isNotEqualTo []}};
+// Remove empty entries
+_secondaryWeaponInfo = _secondaryWeaponInfo select {_x isNotEqualTo "" && {_x isNotEqualTo []}};
 
-    // Remove the tripod from the launcher slot
-    _player removeWeaponGlobal _secondaryWeaponClassname;
+// Remove the tripod from the launcher slot
+_player removeWeaponGlobal _secondaryWeaponClassname;
 
-    private _onFinish = {
-        params ["_args"];
-        _args params ["_player", "_secondaryWeaponClassname", "_secondaryWeaponInfo"];
-        TRACE_3("deployTripod finish",_player,_secondaryWeaponClassname,_secondaryWeaponInfo);
+private _onFinish = {
+    params ["_args"];
+    _args params ["_player", "_secondaryWeaponClassname", "_secondaryWeaponInfo", "_posASL", "_vectorDirAndUp"];
+    TRACE_5("deployTripod finish",_player,_secondaryWeaponClassname,_secondaryWeaponInfo,_posASL,_vectorDirAndUp);
 
-        private _tripodClassname = getText (configFile >> "CfgWeapons" >> _secondaryWeaponClassname >> QUOTE(ADDON) >> "deploy");
+    private _tripodClassname = getText (configFile >> "CfgWeapons" >> _secondaryWeaponClassname >> QUOTE(ADDON) >> "deploy");
 
-        // Create a tripod
-        private _cswTripod = createVehicle [_tripodClassname, [0, 0, 0], [], 0, "NONE"];
-        // Because the tripod can be a "full weapon" we disable any data that will allow it to be loaded
-        _cswTripod setVariable [QGVAR(assemblyMode), 2, true]; // Explicitly set enabled&unload assembly mode and broadcast
+    // Create a tripod
+    private _cswTripod = createVehicle [_tripodClassname, [0, 0, 0], [], 0, "CAN_COLLIDE"];
+    // Because the tripod can be a "full weapon" we disable any data that will allow it to be loaded
+    _cswTripod setVariable [QGVAR(assemblyMode), 2, true]; // Explicitly set enabled&unload assembly mode and broadcast
 
-        private _secondaryWeaponMagazines = [];
+    private _secondaryWeaponMagazines = [];
 
-        {
-            // Magazines
-            if (_x isEqualType []) then {
-                _secondaryWeaponMagazines pushBack _x;
-            } else {
-                // Items
-                [_player, _x, true] call CBA_fnc_addItem;
-            };
-        } forEach _secondaryWeaponInfo;
-
-        // Only add magazines once the weapon is fully ready
-        if (_secondaryWeaponMagazines isNotEqualTo []) then {
-            _cswTripod setVariable [QGVAR(secondaryWeaponMagazines), _secondaryWeaponMagazines, true];
+    {
+        // Magazines
+        if (_x isEqualType []) then {
+            _secondaryWeaponMagazines pushBack _x;
+        } else {
+            // Items
+            [_player, _x, true] call CBA_fnc_addItem;
         };
+    } forEach _secondaryWeaponInfo;
 
-        // Disable vanilla assembly until FUNC(initVehicle) runs and sets the definite value
-        [_cswTripod, "disableWeaponAssembly", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
-
-        private _posATL = _player getRelPos [2, 0];
-        _posATL set [2, ((getPosATL _player) select 2) + 0.5];
-
-        _cswTripod setDir (direction _player);
-        _cswTripod setPosATL _posATL;
-        _cswTripod setVectorUp (surfaceNormal _posATL);
-
-        [_player, "PutDown"] call EFUNC(common,doGesture);
-
-        // drag after deploying
-        if ((missionNamespace getVariable [QGVAR(dragAfterDeploy), false]) && {["ace_dragging"] call EFUNC(common,isModLoaded)}) then {
-            if ([_player, _cswTripod] call EFUNC(dragging,canCarry)) then {
-                TRACE_1("starting carry",_cswTripod);
-                [_player, _cswTripod] call EFUNC(dragging,startCarry);
-            } else {
-                TRACE_1("cannot carry",_cswTripod);
-            };
-        };
+    // Only add magazines once the weapon is fully ready
+    if (_secondaryWeaponMagazines isNotEqualTo []) then {
+        _cswTripod setVariable [QGVAR(secondaryWeaponMagazines), _secondaryWeaponMagazines, true];
     };
 
-    private _onFailure = {
-        params ["_args"];
-        _args params ["_player", "_secondaryWeaponClassname", "_secondaryWeaponInfo"];
-        TRACE_3("deployTripod failure",_player,_secondaryWeaponClassname,_secondaryWeaponInfo);
+    // Disable vanilla assembly until FUNC(initVehicle) runs and sets the definite value
+    [_cswTripod, "disableWeaponAssembly", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
 
-        // Add tripod back
-        [_player, _secondaryWeaponClassname] call CBA_fnc_addWeaponWithoutItems;
+    _cswTripod setPosASL _posASL;
+    _cswTripod setVectorDirAndUp _vectorDirAndUp;
 
-        // Add all attachments back
-        {
-            _player addWeaponItem [_secondaryWeaponClassname, _x, true];
-        } forEach _secondaryWeaponInfo;
+    [_player, "PutDown"] call EFUNC(common,doGesture);
+
+    // drag after deploying
+    if ((missionNamespace getVariable [QGVAR(dragAfterDeploy), false]) && {["ace_dragging"] call EFUNC(common,isModLoaded)}) then {
+        if ([_player, _cswTripod] call EFUNC(dragging,canCarry)) then {
+            TRACE_1("starting carry",_cswTripod);
+            [_player, _cswTripod] call EFUNC(dragging,startCarry);
+        } else {
+            TRACE_1("cannot carry",_cswTripod);
+        };
     };
+};
 
-    private _deployTime = getNumber (configFile >> "CfgWeapons" >> _secondaryWeaponClassname >> QUOTE(ADDON) >> "deployTime");
-    [TIME_PROGRESSBAR(_deployTime), [_player, _secondaryWeaponClassname, _secondaryWeaponInfo], _onFinish, _onFailure, LLSTRING(PlaceTripod_progressBar)] call EFUNC(common,progressBar);
-}, _this] call CBA_fnc_execNextFrame;
+private _onFailure = {
+    params ["_args"];
+    _args params ["_player", "_secondaryWeaponClassname", "_secondaryWeaponInfo"];
+    TRACE_3("deployTripod failure",_player,_secondaryWeaponClassname,_secondaryWeaponInfo);
+
+    // Add tripod back
+    [_player, _secondaryWeaponClassname] call CBA_fnc_addWeaponWithoutItems;
+
+    // Add all attachments back
+    {
+        _player addWeaponItem [_secondaryWeaponClassname, _x, true];
+    } forEach _secondaryWeaponInfo;
+};
+
+private _deployTime = getNumber (configFile >> "CfgWeapons" >> _secondaryWeaponClassname >> QUOTE(ADDON) >> "deployTime");
+[TIME_PROGRESSBAR(_deployTime), [_player, _secondaryWeaponClassname, _secondaryWeaponInfo, _posASL, _vectorDirAndUp], _onFinish, _onFailure, LLSTRING(PlaceTripod_progressBar)] call EFUNC(common,progressBar);

--- a/addons/csw/functions/fnc_assemble_startDeployTripod.sqf
+++ b/addons/csw/functions/fnc_assemble_startDeployTripod.sqf
@@ -40,11 +40,8 @@ _tripodPreviewObject setMass 1e-12;
 // Detect radius of zone where collision can damage the player
 private _tripodPreviewObjectRadius = 1 max ((boundingBoxReal [_tripodPreviewObject, "FireGeometry"]) select 2);
 
-// Add height offset of model
-private _offset = ((_tripodPreviewObject modelToWorldVisual [0, 0, 0]) select 2) - ((_player modelToWorldVisual [0, 0, 0]) select 2) + 1;
-
 // Attach object
-_tripodPreviewObject attachTo [_player, [0, 1.5 * _tripodPreviewObjectRadius, _offset]];
+_tripodPreviewObject attachTo [_player, [0, 1.5 * _tripodPreviewObjectRadius, 1]];
 
 GVAR(placeAction) = PLACE_WAITING;
 

--- a/addons/csw/functions/fnc_assemble_startDeployTripod.sqf
+++ b/addons/csw/functions/fnc_assemble_startDeployTripod.sqf
@@ -1,0 +1,87 @@
+#include "..\script_component.hpp"
+/*
+ * Author: Garth 'L-H' de Wet, Ruthberg, commy2, Smith, johnb43
+ * Starts the deploy process for unloading an object.
+ *
+ * Arguments:
+ * 0: Unit deploying <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * player call ace_csw_fnc_assemble_startDeployTripod
+ *
+ * Public: No
+ */
+
+params ["_player"];
+
+// Don't allow deploying if already deploying
+if (_player getVariable [QGVAR(isDeploying), false]) exitWith {};
+
+private _secondaryWeaponClassname = secondaryWeapon _player;
+private _classname = getText (configFile >> "CfgWeapons" >> _secondaryWeaponClassname >> QUOTE(ADDON) >> "deploy");
+
+// Prevent the placing unit from running
+[_player, "forceWalk", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
+[_player, "blockThrow", QUOTE(ADDON), true] call EFUNC(common,statusEffect_set);
+
+// Create a local preview object
+private _tripodPreviewObject = createVehicleLocal [_classname, [0, 0, 0], [], 0, "CAN_COLLIDE"];
+
+GVAR(tripodPreviewObject) = _tripodPreviewObject;
+
+// Prevent collisions with object
+_tripodPreviewObject disableCollisionWith _player;
+_tripodPreviewObject enableSimulation false;
+_tripodPreviewObject setMass 1e-12;
+
+// Detect radius of zone where collision can damage the player
+private _tripodPreviewObjectRadius = 1 max ((boundingBoxReal [_tripodPreviewObject, "FireGeometry"]) select 2);
+
+// Add height offset of model
+private _offset = ((_tripodPreviewObject modelToWorldVisual [0, 0, 0]) select 2) - ((_player modelToWorldVisual [0, 0, 0]) select 2) + 1;
+
+// Attach object
+_tripodPreviewObject attachTo [_player, [0, 1.5 * _tripodPreviewObjectRadius, _offset]];
+
+GVAR(placeAction) = PLACE_WAITING;
+
+// PFH that runs while the deployment is in progress
+GVAR(deployPFH) = [{
+    (_this select 0) params ["_player", "_secondaryWeaponClassname", "_tripodPreviewObject"];
+
+    // Cancel deployment if criteria not met
+    if (
+        isNull _tripodPreviewObject ||
+        {secondaryWeapon _player != _secondaryWeaponClassname} ||
+        {!(_player call FUNC(canDeployTripod))} ||
+        {GVAR(placeAction) == PLACE_CANCEL}
+    ) exitWith {
+        _player call FUNC(deployCancel);
+    };
+
+    // Check if the center of the object is not inside another (don't check for other intersections though)
+    private _validPosition = (lineIntersectsSurfaces [eyePos _player, getPosASL _tripodPreviewObject, _player]) isEqualTo [];
+
+    // Update mouse hint
+    ((uiNamespace getVariable [QEGVAR(interaction,mouseHint), displayNull]) displayCtrl 2420) ctrlSetText (localize ([LSTRING(BlockedAction), LSTRING(PlaceAction)] select _validPosition));
+
+    if (GVAR(placeAction) != PLACE_APPROVE) exitWith {};
+
+    // Deploy the CSW
+    if (_validPosition) exitWith {
+        _player call FUNC(deployConfirm);
+    };
+
+    // Don't allow placing in an invalid position
+    GVAR(placeAction) = PLACE_WAITING;
+}, 0, [_player, _secondaryWeaponClassname, _tripodPreviewObject]] call CBA_fnc_addPerFrameHandler;
+
+// Add mouse button action and hint
+[LLSTRING(PlaceAction), LELSTRING(common,Cancel), LLSTRING(RaiseLowerRotate)] call EFUNC(interaction,showMouseHint);
+
+_player setVariable [QGVAR(deploy), [_player, "DefaultAction", {GVAR(deployPFH) != -1}, {GVAR(placeAction) = PLACE_APPROVE}] call EFUNC(common,addActionEventHandler)];
+
+_player setVariable [QGVAR(isDeploying), true, true];

--- a/addons/csw/functions/fnc_cancelDeployTripod.sqf
+++ b/addons/csw/functions/fnc_cancelDeployTripod.sqf
@@ -1,0 +1,22 @@
+#include "..\script_component.hpp"
+/*
+ * Author: Garth 'L-H' de Wet, johnb43
+ * Cancels CSW tripod placement.
+ *
+ * Arguments:
+ * 0: Key <NUMBER>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * 1 call ace_csw_fnc_cancelDeployTripod
+ *
+ * Public: No
+ */
+
+params ["_key"];
+
+if (_key != 1 || {GVAR(deployPFH) == -1}) exitWith {};
+
+GVAR(placeAction) = PLACE_CANCEL;

--- a/addons/csw/functions/fnc_deployCancel.sqf
+++ b/addons/csw/functions/fnc_deployCancel.sqf
@@ -1,0 +1,39 @@
+#include "..\script_component.hpp"
+/*
+ * Author: Garth 'L-H' de Wet, Ruthberg, commy2, Smith, johnb43
+ * Cancels unloading when deploying.
+ *
+ * Arguments:
+ * 0: Unit <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * player call ace_csw_fnc_deployCancel
+ *
+ * Public: No
+ */
+
+if (GVAR(deployPFH) == -1) exitWith {};
+
+// Remove deployment pfh
+GVAR(deployPFH) call CBA_fnc_removePerFrameHandler;
+GVAR(deployPFH) = -1;
+
+params ["_player"];
+
+// Enable running again
+[_player, "forceWalk", QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
+[_player, "blockThrow", QUOTE(ADDON), false] call EFUNC(common,statusEffect_set);
+
+// Delete placement dummy
+deleteVehicle GVAR(tripodPreviewObject);
+
+// Remove mouse button actions
+call EFUNC(interaction,hideMouseHint);
+
+[_player, "DefaultAction", _player getVariable [QGVAR(deploy), -1]] call EFUNC(common,removeActionEventHandler);
+_player setVariable [QGVAR(deploy), -1];
+
+_player setVariable [QGVAR(isDeploying), false, true];

--- a/addons/csw/functions/fnc_deployConfirm.sqf
+++ b/addons/csw/functions/fnc_deployConfirm.sqf
@@ -1,0 +1,41 @@
+#include "..\script_component.hpp"
+/*
+ * Author: Garth 'L-H' de Wet, Ruthberg, commy2, Smith, johnb43
+ * Confirms unloading when deploying.
+ *
+ * Arguments:
+ * 0: Unit <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * player call ace_csw_fnc_deployConfirm
+ *
+ * Public: No
+ */
+
+if (GVAR(deployPFH) == -1) exitWith {};
+
+params ["_player"];
+
+// Delete placement dummy and place real tripod at dummy position
+if (!isNull GVAR(tripodPreviewObject) && {_player call FUNC(canDeployTripod)}) then {
+    private _posASL = getPosASL GVAR(tripodPreviewObject);
+    private _intersect = lineIntersectsSurfaces [_posASL, _posASL vectorAdd [0, 0, -1.5], _player, GVAR(tripodPreviewObject), true, 1, "ROADWAY", "FIRE"];
+
+    private _vectorUp = if (_intersect isNotEqualTo []) then {
+        (_intersect select 0) params ["_intersectPosASL", "_normal"];
+
+        _posASL = _intersectPosASL;
+
+        _normal
+    } else {
+        vectorUp GVAR(tripodPreviewObject)
+    };
+
+    [_player, _posASL, [vectorDir GVAR(tripodPreviewObject), _vectorUp]] call FUNC(assemble_deployTripod);
+};
+
+// Cleanup EHs and preview object
+_player call FUNC(deployCancel);

--- a/addons/csw/functions/fnc_handleScrollWheel.sqf
+++ b/addons/csw/functions/fnc_handleScrollWheel.sqf
@@ -1,0 +1,56 @@
+#include "..\script_component.hpp"
+/*
+ * Author: L-H, commy2, Smith
+ * Handles rotation of object to unload.
+ *
+ * Arguments:
+ * 0: Scroll amount <NUMBER>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * 1.2 call ace_csw_fnc_handleScrollWheel
+ *
+ * Public: No
+ */
+
+if (GVAR(deployPFH) == -1) exitWith {};
+
+params ["_scrollAmount"];
+
+private _deployedItem = GVAR(tripodPreviewObject);
+
+if (!CBA_events_control) then {
+    private _player = ACE_player;
+
+    // Raise/lower
+    // Move deployed item 10 cm per scroll interval
+    _scrollAmount = _scrollAmount * 0.1;
+
+    private _position = getPosASL _deployedItem;
+    private _maxHeight = (_player modelToWorldVisualWorld [0, 0, 0]) select 2;
+
+    _position set [2, ((_position select 2) + _scrollAmount min (_maxHeight + 1.5)) max _maxHeight];
+
+    // Move up/down object and reattach at current position
+    detach _deployedItem;
+
+    // Uses this method of selecting position because setPosATL did not have immediate effect
+    private _positionChange = _position vectorDiff (getPosASL _deployedItem);
+    private _selectionPosition = _player worldToModel (ASLToAGL getPosWorld _deployedItem);
+    _selectionPosition = _selectionPosition vectorAdd _positionChange;
+    _deployedItem attachTo [_player, _selectionPosition];
+
+    // Reset the deploy direction
+    private _direction = _deployedItem getVariable [QGVAR(deployDirection_temp), 0];
+    _deployedItem setDir _direction;
+} else {
+    // Rotate
+    private _direction = _deployedItem getVariable [QGVAR(deployDirection_temp), 0];
+    _scrollAmount = _scrollAmount * 10;
+    _direction = _direction + _scrollAmount;
+
+    _deployedItem setDir _direction;
+    _deployedItem setVariable [QGVAR(deployDirection_temp), _direction];
+};

--- a/addons/csw/script_component.hpp
+++ b/addons/csw/script_component.hpp
@@ -31,3 +31,7 @@
 #define M2_MASS 840 // 84 pound M2 Browning
 #define M2_SIGHT_MASS 62 // 4.2 pound Trijicon MGRS + ~2 pound mounting adaptor
 #define M2_SHIELD_MASS 550 // 55 pound ~800x450x8 millimeter steel plate and mounting arms
+
+#define PLACE_WAITING -1
+#define PLACE_CANCEL 0
+#define PLACE_APPROVE 1

--- a/addons/csw/stringtable.xml
+++ b/addons/csw/stringtable.xml
@@ -126,6 +126,23 @@
             <Chinesesimp>正在组装武器...</Chinesesimp>
             <Ukrainian>Збірка зброї...</Ukrainian>
         </Key>
+        <Key ID="STR_ACE_CSW_BlockedAction">
+            <English>Blocked</English>
+            <Czech>Blokováno</Czech>
+            <French>Bloqué</French>
+            <Spanish>Obstruido</Spanish>
+            <Italian>Bloccato</Italian>
+            <Polish>Zablokowany</Polish>
+            <Portuguese>Bloqueado</Portuguese>
+            <Russian>Заблокировано</Russian>
+            <German>Blockiert</German>
+            <Korean>막힘</Korean>
+            <Japanese>取り付け不可</Japanese>
+            <Chinese>斷開</Chinese>
+            <Chinesesimp>断开</Chinesesimp>
+            <Turkish>Bloke Edilmiş</Turkish>
+            <Ukrainian>Заблоковано</Ukrainian>
+        </Key>
         <Key ID="STR_ACE_CSW_DisableAutoFire_displayName">
             <English>Disable fire on load</English>
             <French>Désactiver le tir à l'armement</French>
@@ -272,6 +289,24 @@
             <Chinesesimp>捡起三脚架</Chinesesimp>
             <Ukrainian>Підібрати триногу</Ukrainian>
         </Key>
+        <Key ID="STR_ACE_CSW_PlaceAction">
+            <English>Place</English>
+            <Czech>Položit</Czech>
+            <French>Placer</French>
+            <Spanish>Colocar</Spanish>
+            <Italian>Piazza</Italian>
+            <Polish>Umieść</Polish>
+            <Portuguese>Colocar</Portuguese>
+            <Russian>Установить</Russian>
+            <German>Platzieren</German>
+            <Korean>설치</Korean>
+            <Japanese>設置</Japanese>
+            <Chinese>放置</Chinese>
+            <Chinesesimp>放置</Chinesesimp>
+            <Turkish>Yerleştir</Turkish>
+            <Hungarian>Elhelyezés</Hungarian>
+            <Ukrainian>Встановити</Ukrainian>
+        </Key>
         <Key ID="STR_ACE_CSW_PlaceTripod_displayName">
             <English>Place Tripod</English>
             <Czech>Položit trojnožku</Czech>
@@ -304,6 +339,22 @@
             <Chinese>部署三腳架...</Chinese>
             <Chinesesimp>部署三脚架...</Chinesesimp>
             <Ukrainian>Розміщення триноги...</Ukrainian>
+        </Key>
+        <Key ID="STR_ACE_CSW_RaiseLowerRotate">
+            <English>Raise/Lower | (Ctrl + Scroll) Rotate</English>
+            <Czech>Zvednout/Snížit | (Ctrl + Kolečko myši) Otáčet</Czech>
+            <French>Lever/Baisser | (Ctrl + Scroll) Rotation</French>
+            <Spanish>Subir/Bajar | (Ctrl + Scroll) Rotar</Spanish>
+            <Italian>Alza/Abbassa | (Ctrl + Rotellina) Ruota</Italian>
+            <Polish>Wyżej/niżej | (Ctrl + Kółko myszy) obracanie</Polish>
+            <Portuguese>Subir/Abaixar | (Ctrl + Scroll) Rotacionar</Portuguese>
+            <Russian>Поднять/опустить | (Ctrl + Скролл) Крутить</Russian>
+            <German>Heben/Senken | (Strg + Scrollen) Drehen</German>
+            <Korean>높이기/내리기 | (컨트롤 + 스크롤) 회전</Korean>
+            <Japanese>上げる/下げる | (Ctrl + スクロール) 回転</Japanese>
+            <Chinesesimp>抬起/放低 |（Ctrl + 鼠标滚轮）旋转</Chinesesimp>
+            <Turkish>Yükselt/Alçalt | (Ctrl + Tekerlek) Döndür</Turkish>
+            <Ukrainian>Підняти/опустити | (Ctrl + Скрол) Крутити</Ukrainian>
         </Key>
         <Key ID="STR_ACE_CSW_StaticAABag_displayName">
             <English>[CSW] Static Mini-Spike Launcher (AA)</English>


### PR DESCRIPTION
**When merged this pull request will:**
- Similar to cargo's deploy.
  - Instead of placing randomly, you now must place the tripod yourself.
  - A preview object allows you to place the tripod (position + rotation around z-axis).
  - Once you confirm the deployment, it will start the progressbar.
  - Once the progressbar has finished, it will place the tripod at the same position with the same rotation as the preview object.
  - If there is a surface below the tripod, it will snap the tripod to said surface.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
