### PR TITLE
Common - Add `ace_scriptedNameSet` to prevent overwriting name

### DIFF
--- a/addons/common/functions/fnc_setName.sqf
+++ b/addons/common/functions/fnc_setName.sqf
@@ -24,10 +24,11 @@ TRACE_4("setName",_unit,alive _unit,_name,_forceSet);
 
 if (isNull _unit || {!alive _unit} || { !(_unit isKindOf "CAManBase") }) exitWith {};
 
-if (_forceSet || _unit isNil "ACE_Name") then {
+if (_forceSet || !(_unit getVariable ["ace_setCustomName", false])) then {
     private _sanitizedName = [_name, true] call FUNC(sanitizeString);
     private _rawName = [_name, false] call FUNC(sanitizeString);
 
     _unit setVariable ["ACE_Name", _sanitizedName, true];
     _unit setVariable ["ACE_NameRaw", _rawName, true];
+    _unit setVariable ["ace_setCustomName", nil, true];
 };

--- a/addons/common/functions/fnc_setName.sqf
+++ b/addons/common/functions/fnc_setName.sqf
@@ -1,10 +1,11 @@
 #include "..\script_component.hpp"
 /*
- * Author: commy2
+ * Author: commy2, DartRuffian
  * Sets the name variable of the object. Used to prevent issues with the name command.
  *
  * Arguments:
  * 0: Object <OBJECT>
+ * 1: Force set name (optional, default: false) <BOOL>
  *
  * Return Value:
  * None
@@ -15,14 +16,17 @@
  * Public: No
  */
 
-params ["_unit"];
-TRACE_3("setName",_unit,alive _unit,name _unit);
+params ["_unit", ["_forceSet", false]];
 
-if (isNull _unit || {!alive _unit}) exitWith {};
+private _name = name _unit;
 
-if (_unit isKindOf "CAManBase") then {
-    private _sanitizedName = [name _unit, true] call FUNC(sanitizeString);
-    private _rawName = [name _unit, false] call FUNC(sanitizeString);
+TRACE_3("setName",_unit,alive _unit,_name);
+
+if (isNull _unit || {!alive _unit} || { !(_unit isKindOf "CAManBase") }) exitWith {};
+
+if (_forceSet || _unit isNil "ACE_Name") then {
+    private _sanitizedName = [_name, true] call FUNC(sanitizeString);
+    private _rawName = [_name, false] call FUNC(sanitizeString);
 
     _unit setVariable ["ACE_Name", _sanitizedName, true];
     _unit setVariable ["ACE_NameRaw", _rawName, true];

--- a/addons/common/functions/fnc_setName.sqf
+++ b/addons/common/functions/fnc_setName.sqf
@@ -20,7 +20,7 @@ params ["_unit", ["_forceSet", false]];
 
 private _name = name _unit;
 
-TRACE_3("setName",_unit,alive _unit,_name);
+TRACE_4("setName",_unit,alive _unit,_name,_forceSet);
 
 if (isNull _unit || {!alive _unit} || { !(_unit isKindOf "CAManBase") }) exitWith {};
 

--- a/docs/wiki/framework/common-framework.md
+++ b/docs/wiki/framework/common-framework.md
@@ -24,3 +24,12 @@ class CfgWeapons {
     };
 };
 ```
+
+## 2. Variables
+
+### 2.1 Scripted `ace_name`
+
+Unit's name (`"ACE_Name"`/ `"ACE_NameRaw"`) can be manualy scritped and locked by setting
+```cpp
+unit setVariable ["ace_setCustomName", true]
+```


### PR DESCRIPTION
**When merged this pull request will:**
- Add `ace_scriptedNameSet` to prevent overwriting custom name
- Added param (default false) to force re-set name 

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
