### PR TITLE
Tools - Define permissions for GitHub workflows

### DIFF
--- a/.github/workflows/arma.yml
+++ b/.github/workflows/arma.yml
@@ -6,6 +6,11 @@ on:
     - master
   pull_request:
 
+permissions:
+  contents: read
+  checks: write
+  statuses: write
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -6,6 +6,9 @@ on:
     - master
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: "pages"
   cancel-in-progress: false

--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -8,6 +8,9 @@ on:
     - 'Cargo.lock'
     - '.github/workflows/extensions.yml'
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/hemtt.yml
+++ b/.github/workflows/hemtt.yml
@@ -6,6 +6,11 @@ on:
     - master
   pull_request_target:
 
+permissions:
+  contents: read
+  checks: write
+  statuses: write
+
 jobs:
   windows:
     runs-on: windows-latest
@@ -22,6 +27,7 @@ jobs:
       uses: actions/checkout@v6
       if: ${{ github.event_name == 'pull_request_target' }}
       with:
+        allow-unsafe-pr-checkout: true
         path: pullrequest
         ref: 'refs/pull/${{ github.event.number }}/merge'
     - name: Replace addons with pull request addons

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,6 +5,10 @@ on:
     branches:
     - master
 
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   draft:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**When merged this pull request will:**
- tile
- more secure workflows as per GitHub guidinelines
    - https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target
    - https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions

### IMPORTANT

I'm not an expert on GitHub permissions, I think arma.yml/hemtt.yml workflows need `checks: write`, and `statuses: write` to properly add stuff like build status or source code inline annotations (from hemtt) to the commits.