### PR TITLE
Wardrobe - Remove API Parameter `_extendedInfo`

### DIFF
--- a/addons/wardrobe/functions/fnc_replace.sqf
+++ b/addons/wardrobe/functions/fnc_replace.sqf
@@ -66,17 +66,16 @@ private _replaceData = createHashMapFromArray [
     ["typeTarget", _typeTarget]
 ];
 
-private _extendedInfo = createHashMap;
-[QGVAR(itemChangedStart), [_replaceData, _extendedInfo]] call CBA_fnc_localEvent; // API
+[QGVAR(itemChangedStart), [_replaceData]] call CBA_fnc_localEvent; // API
 
 [{
-    params ["_replaceData", "_replaceCode", "_extendedInfo"];
+    params ["_replaceData", "_replaceCode"];
 
-    [QGVAR(itemChangedBegin), [_replaceData, _extendedInfo]] call CBA_fnc_localEvent; // API
+    [QGVAR(itemChangedBegin), [_replaceData]] call CBA_fnc_localEvent; // API
     _replaceData call _replaceCode;
-    [QGVAR(itemChangedEnd), [_replaceData, _extendedInfo]] call CBA_fnc_localEvent; // API
+    [QGVAR(itemChangedEnd), [_replaceData]] call CBA_fnc_localEvent; // API
 
-}, [_replaceData, _replaceCode, _extendedInfo], _duration] call CBA_fnc_waitAndExecute;
+}, [_replaceData, _replaceCode], _duration] call CBA_fnc_waitAndExecute;
 
 
 // HANDLE COMPONENTS

--- a/docs/wiki/framework/wardrobe-framework.md
+++ b/docs/wiki/framework/wardrobe-framework.md
@@ -392,13 +392,12 @@ Therefore, the debug script found at `addons\wardrobe\dev\compareContainerMaxLoa
   - `"classTarget"` - Classname
   - `"typeOrigin"` - Typenumber, see [script_macros.hpp](https://github.com/acemod/ACE3/blob/master/addons/main/script_macros.hpp#L75-L114)
   - `"typeTarget"` - Typenumber, see [script_macros.hpp](https://github.com/acemod/ACE3/blob/master/addons/main/script_macros.hpp#L75-L114)
-- `_extendedInfo` is HASHMAP will be passed between events (works similar to `CBA_loadoutSet` events)
 
 | Event Name | Description | Passed Parameter(s) | Locality |
 | ---------- | ----------- | ------------------- | -------- |
-| `ace_wardrobe_itemChangedStart` | Raised when the action to change an item is taken, but before any changes. | `[_replaceData, _extendedInfo]` | Local |
-| `ace_wardrobe_itemChangedBegin` | Raised just before the item is changed. | `[_replaceData, _extendedInfo]` | Local |
-| `ace_wardrobe_itemChangedEnd` | Raised just after the item has been changed. | `[_replaceData, _extendedInfo]` | Local |
+| `ace_wardrobe_itemChangedStart` | Raised when the action to change an item is taken, but before any changes. | `[_replaceData]` | Local |
+| `ace_wardrobe_itemChangedBegin` | Raised just before the item is changed. | `[_replaceData]` | Local |
+| `ace_wardrobe_itemChangedEnd` | Raised just after the item has been changed. | `[_replaceData]` | Local |
 
 ## 6.4 Container Variables
 


### PR DESCRIPTION
`_extendedInfo` is redundant, as `_replaceData` is already a hashmap which can be used to store data between API events.