### PR TITLE
Quick Mount - Add setting for 3d seat actions

### DIFF
--- a/addons/quickmount/CfgVehicles.hpp
+++ b/addons/quickmount/CfgVehicles.hpp
@@ -42,7 +42,7 @@ class CfgVehicles {
             class ACE_MainActions { \
                 class GVAR(GetIn) { \
                     displayName = "$STR_rscMenu.hppRscGroupRootMenu_Items_GetIn1"; \
-                    condition = QUOTE(call DFUNC(canShowFreeSeats) && {_actionParams set [ARR_2(0,call DFUNC(addFreeSeatsActions))];_actionParams select 0 isNotEqualTo []}); \
+                    condition = QUOTE([ARR_3(_target,_player,true)] call DFUNC(canShowFreeSeats) && {_actionParams set [ARR_2(0,call DFUNC(addFreeSeatsActions))];_actionParams select 0 isNotEqualTo []}); \
                     statement = QUOTE(call DFUNC(getInNearest)); \
                     exceptions[] = {"isNotSwimming"}; \
                     insertChildren = QUOTE(_actionParams param [ARR_2(0,[])]); \
@@ -53,7 +53,7 @@ class CfgVehicles {
             class GVAR(ChangeSeat) { \
                 displayName = CSTRING(ChangeSeat); \
                 icon = QPATHTOF(UI\Seats_ca.paa); \
-                condition = QUOTE(call DFUNC(canShowFreeSeats)); \
+                condition = QUOTE([ARR_3(_target,_player,true)] call DFUNC(canShowFreeSeats)); \
                 insertChildren = QUOTE(call DFUNC(addFreeSeatsActions)); \
             }; \
         }

--- a/addons/quickmount/XEH_postInitClient.sqf
+++ b/addons/quickmount/XEH_postInitClient.sqf
@@ -8,4 +8,4 @@ if (!hasInterface) exitWith {};
     };
 }] call CBA_fnc_addKeybind;
 
-GVAR(initializedVehicleClasses) = [];
+GVAR(initializedVehicleClasses) = createHashMap;

--- a/addons/quickmount/functions/fnc_addGetInActions.sqf
+++ b/addons/quickmount/functions/fnc_addGetInActions.sqf
@@ -39,7 +39,7 @@ if (_model == getText (_vehicleConfig >> "model")) then {
 TRACE_4("addGetInActions",_vehicleClass,_cargoProxyIndexes,_seatPositions,_seatProxies);
 
 private _conditionCrew = {
-    call FUNC(canShowFreeSeats)
+    [_target, _player, false] call FUNC(canShowFreeSeats)
     && {!isNull ([_target, _actionParams select 0] call FUNC(getSeatUnit))}
 };
 private _insertChildrenCrew = {
@@ -76,7 +76,7 @@ private _cargoPositionNumber = -1;
             _proxyIndex = 1;
             _params = [_turretPath];
             _condition = {
-                call FUNC(canShowFreeSeats)
+                [_target, _player, false] call FUNC(canShowFreeSeats)
                 && {!lockedDriver _target}
                 && {!alive driver _target}
             };
@@ -89,7 +89,7 @@ private _cargoPositionNumber = -1;
             _proxyIndex = _cargoProxyIndexes param [_cargoPositionNumber, _cargoPositionNumber + 1];
             _params = [_cargoIndex, _cargoPositionNumber];
             _condition = {
-                call FUNC(canShowFreeSeats)
+                [_target, _player, false] call FUNC(canShowFreeSeats)
                 && {
                     private _cargoIndex = _actionParams select 0;
                     !(_target lockedCargo _cargoIndex)
@@ -112,7 +112,7 @@ private _cargoPositionNumber = -1;
             _proxyIndex = getNumber (_turretConfig >> "proxyIndex");
             _params = [_turretPath];
             _condition = {
-                call FUNC(canShowFreeSeats)
+                [_target, _player, false] call FUNC(canShowFreeSeats)
                 && {
                     private _turretPath = _actionParams select 0;
                     !(_target lockedTurret _turretPath)

--- a/addons/quickmount/functions/fnc_canShowFreeSeats.sqf
+++ b/addons/quickmount/functions/fnc_canShowFreeSeats.sqf
@@ -7,7 +7,7 @@
  * Arguments:
  * 0: Vehicle <OBJECT>
  * 1: Unit <OBJECT>
- * 2: Menu (true for menu, false for 3d interactions) <BOOL>
+ * 2: Menu (true for menu, false for 3d interactions) <BOOL> (default: true)
  * 3: Use cache <BOOL> (default: true)
  *
  * Return Value:
@@ -21,13 +21,13 @@
 
 params ["_vehicle", "_unit", ["_menu", true], ["_useCache", true]];
 
-private _isInVehicle = _unit in _vehicle;
-
-// function is called by multiple actions and MainAction
-if (!_isInVehicle && {_useCache}) exitWith {
+// function is called by multiple actions
+if (!_menu && {_useCache}) exitWith {
     _this set [3, false];
-    [_this, LINKFUNC(canShowFreeSeats), _vehicle, format [QGVAR(canShowFreeSeats%1), _menu], 1] call EFUNC(common,cachedCall) // return
+    [_this, LINKFUNC(canShowFreeSeats), _vehicle, QGVAR(canShowFreeSeats_3d), 1] call EFUNC(common,cachedCall) // return
 };
+
+private _isInVehicle = _unit in _vehicle;
 
 TRACE_6("canShowFreeSeats",_vehicle,typeOf _vehicle,_unit,_isInVehicle,_menu,_useCache);
 
@@ -55,7 +55,7 @@ GVAR(enabled)
     || {_vehicle isKindOf "Air"} // except Air
 }
 && {
-    _isInVehicle
+    _menu
     || {GVAR(initializedVehicleClasses) getOrDefaultCall [typeOf _vehicle, {
         _vehicle call FUNC(addGetInActions);
         true

--- a/addons/quickmount/functions/fnc_canShowFreeSeats.sqf
+++ b/addons/quickmount/functions/fnc_canShowFreeSeats.sqf
@@ -7,35 +7,43 @@
  * Arguments:
  * 0: Vehicle <OBJECT>
  * 1: Unit <OBJECT>
- * 2: Args <ARRAY>
+ * 2: Menu (true for menu, false for 3d interactions) <BOOL>
  * 3: Use cache <BOOL> (default: true)
  *
  * Return Value:
  * Can show menu <BOOL>
  *
  * Example:
- * [cursorObject, player] call ace_quickmount_fnc_canShowFreeSeats
+ * [cursorObject, player, true] call ace_quickmount_fnc_canShowFreeSeats
  *
  * Public: No
  */
 
-params ["_vehicle", "_unit", ["_args", []], ["_useCache", true]];
+params ["_vehicle", "_unit", ["_menu", true], ["_useCache", true]];
 
 private _isInVehicle = _unit in _vehicle;
 
 // function is called by multiple actions and MainAction
 if (!_isInVehicle && {_useCache}) exitWith {
     _this set [3, false];
-    [_this, LINKFUNC(canShowFreeSeats), _vehicle, QGVAR(canShowFreeSeats), 1] call EFUNC(common,cachedCall) // return
+    [_this, LINKFUNC(canShowFreeSeats), _vehicle, format [QGVAR(canShowFreeSeats%1), _menu], 1] call EFUNC(common,cachedCall) // return
 };
 
-TRACE_6("canShowFreeSeats",_vehicle,typeOf _vehicle,_unit,_isInVehicle,_args,_useCache);
+TRACE_6("canShowFreeSeats",_vehicle,typeOf _vehicle,_unit,_isInVehicle,_menu,_useCache);
 
 GVAR(enabled)
 && {
-    GVAR(enableMenu) == 3
-    || {_isInVehicle && {GVAR(enableMenu) == 2}}
-    || {!_isInVehicle && {GVAR(enableMenu) == 1}}
+    if (_menu) then {
+        GVAR(enableMenu) == 3
+        || {_isInVehicle && {GVAR(enableMenu) == 2}}
+        || {!_isInVehicle && {GVAR(enableMenu) == 1}}
+    } else {
+        switch (GVAR(enable3d)) do {
+            case 2: {true};
+            case 1: {CBA_events_shift};
+            default {false};
+        }
+    }
 }
 && {alive _vehicle}
 && {locked _vehicle < 2}
@@ -48,11 +56,8 @@ GVAR(enabled)
 }
 && {
     _isInVehicle
-    || {typeOf _vehicle in GVAR(initializedVehicleClasses)}
-    || {
-        // init vehicle actions here to skip useless checks on clients with disabled quickmount
-        GVAR(initializedVehicleClasses) pushBack typeOf _vehicle;
+    || {GVAR(initializedVehicleClasses) getOrDefaultCall [typeOf _vehicle, {
         _vehicle call FUNC(addGetInActions);
         true
-    }
+    }, true]}
 }

--- a/addons/quickmount/functions/fnc_canShowFreeSeats.sqf
+++ b/addons/quickmount/functions/fnc_canShowFreeSeats.sqf
@@ -22,7 +22,7 @@
 params ["_vehicle", "_unit", ["_menu", true], ["_useCache", true]];
 
 // function is called by multiple actions
-if (!_menu && {_useCache}) exitWith {
+if (!_menu && _useCache) exitWith {
     _this set [3, false];
     [_this, LINKFUNC(canShowFreeSeats), _vehicle, QGVAR(canShowFreeSeats_3d), 1] call EFUNC(common,cachedCall) // return
 };
@@ -34,6 +34,11 @@ TRACE_6("canShowFreeSeats",_vehicle,typeOf _vehicle,_unit,_isInVehicle,_menu,_us
 GVAR(enabled)
 && {
     if (_menu) then {
+        // add 3d interactions for vehicles now
+        GVAR(initializedVehicleClasses) getOrDefaultCall [typeOf _vehicle, {
+            _vehicle call FUNC(addGetInActions);
+            true
+        }, true];
         GVAR(enableMenu) == 3
         || {_isInVehicle && {GVAR(enableMenu) == 2}}
         || {!_isInVehicle && {GVAR(enableMenu) == 1}}
@@ -53,11 +58,4 @@ GVAR(enabled)
 && {
     vectorUp _vehicle select 2 > 0.3 // moveIn* and GetIn* don't work for flipped vehicles
     || {_vehicle isKindOf "Air"} // except Air
-}
-&& {
-    _menu
-    || {GVAR(initializedVehicleClasses) getOrDefaultCall [typeOf _vehicle, {
-        _vehicle call FUNC(addGetInActions);
-        true
-    }, true]}
 }

--- a/addons/quickmount/initSettings.inc.sqf
+++ b/addons/quickmount/initSettings.inc.sqf
@@ -52,3 +52,19 @@ private _category = [ELSTRING(common,ACEKeybindCategoryVehicles), LLSTRING(Categ
         3
     ]
 ] call CBA_fnc_addSetting;
+
+[
+    QGVAR(enable3d),
+    "LIST",
+    [LSTRING(enable3d), LSTRING(enable3d_Description)],
+    _category,
+    [
+        [0,1,2],
+        [
+            ELSTRING(common,Disabled),
+            LSTRING(enable3d_shiftKey),
+            ELSTRING(common,Enabled)
+        ],
+        2
+    ]
+] call CBA_fnc_addSetting;

--- a/addons/quickmount/stringtable.xml
+++ b/addons/quickmount/stringtable.xml
@@ -220,5 +220,14 @@
             <Turkish>Araç Kilitli</Turkish>
             <Ukrainian>Техніка закрита</Ukrainian>
         </Key>
+        <Key ID="STR_ACE_QuickMount_enable3d">
+            <English>Show Seat Actions</English>
+        </Key>
+        <Key ID="STR_ACE_QuickMount_enable3d_Description">
+            <English>Show get-in action for every seat in 3d interaction</English>
+        </Key>
+        <Key ID="STR_ACE_QuickMount_enable3d_shiftKey">
+            <English>When holding SHIFT</English>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
ref https://github.com/acemod/ACE3/pull/11380
Tag @Dystopian for their feedback

Adds new setting for the 3d interaction seats
off, on and when holding shift

because of condition cache (from interaction menu), the seat actions could take a second to show
but I think this is still a good way to de-clutter the menu but still allow the feature to be used
default is full-enabled