### PR TITLE
Medical GUI - Change setting to play effect instead of hint

### DIFF
--- a/addons/medical_gui/XEH_postInit.sqf
+++ b/addons/medical_gui/XEH_postInit.sqf
@@ -43,6 +43,14 @@ GVAR(selfInteractionActions) = [];
 }] call CBA_fnc_addEventHandler;
 
 ["ace_medicalMenuOpened", LINKFUNC(showMedicalHint)] call CBA_fnc_addEventHandler;
+[QGVAR(medicalHint), {
+    params ["_medic", "_msgArray"];
+    switch (GVAR(medicalHintEnabled)) do {
+        case 0: {};
+        case 1: { _msgArray call EFUNC(common,displayTextPicture) };
+        case 2: { playSound3D ["\A3\Sounds_F\characters\ingame\AinvPknlMstpSlayWpstDnon_medicIn.wss", _medic, false, _medic, 0.5, 1, 0, 0, true] }; // local only
+    };
+}] call CBA_fnc_addEventHandler;
 
 [QEGVAR(medical,woundReceived), {
     params ["_unit", "_allDamages", ""];

--- a/addons/medical_gui/XEH_postInit.sqf
+++ b/addons/medical_gui/XEH_postInit.sqf
@@ -46,7 +46,6 @@ GVAR(selfInteractionActions) = [];
 [QGVAR(medicalHint), {
     params ["_medic", "_msgArray"];
     switch (GVAR(medicalHintEnabled)) do {
-        case 0: {};
         case 1: { _msgArray call EFUNC(common,displayTextPicture) };
         case 2: { playSound3D ["\A3\Sounds_F\characters\ingame\AinvPknlMstpSlayWpstDnon_medicIn.wss", _medic, false, _medic, 0.5, 1, 0, 0, true] }; // local only
     };

--- a/addons/medical_gui/functions/fnc_showMedicalHint.sqf
+++ b/addons/medical_gui/functions/fnc_showMedicalHint.sqf
@@ -19,7 +19,7 @@
 params ["_medic", "_patient"];
 TRACE_2("fnc_showMedicalHint",_medic,_patient);
 
-if (!GVAR(medicalHintEnabled) || GVAR(medicalHintMessage) == "" || GVAR(pendingReopen) ||
+if (GVAR(medicalHintMessage) == "" || GVAR(pendingReopen) ||
     _medic == _patient || !(_patient call EFUNC(common,isPlayer))
 ) exitWith {};
 
@@ -35,4 +35,4 @@ if (GVAR(medicalHintMedicIcon) != "" && {_medic call EFUNC(medical_treatment,isM
     };
 };
 
-[QEGVAR(common,displayTextPicture), [_message, _image, [1, 1, 1], _patient], _patient] call CBA_fnc_targetEvent;
+[QGVAR(medicalHint), [_medic, [_message, _image, [1, 1, 1], _patient]], _patient] call CBA_fnc_targetEvent;

--- a/addons/medical_gui/initSettings.inc.sqf
+++ b/addons/medical_gui/initSettings.inc.sqf
@@ -183,11 +183,15 @@ private _categoryColors = [ELSTRING(medical,Interface_Category), format ["| %1 |
 
 [
     QGVAR(medicalHintEnabled),
-    "CHECKBOX",
+    "LIST",
     [LSTRING(medicalHintEnabled_DisplayName), LSTRING(medicalHintEnabled_Description)],
     [ELSTRING(medical,Interface_Category), LSTRING(SubCategory)],
-    true,
-    1
+    [
+        [0, 1, 2],
+        [ELSTRING(common,Disabled), ELSTRING(common,Enabled), LSTRING(medicalHintEnabled_justSound)],
+        1
+    ],
+    0
 ] call CBA_fnc_addSetting;
 
 [

--- a/addons/medical_gui/stringtable.xml
+++ b/addons/medical_gui/stringtable.xml
@@ -1707,6 +1707,9 @@
             <Russian>Включено сообщение медицинского меню</Russian>
             <Japanese>医療メニューメッセージ有効化</Japanese>
         </Key>
+        <Key ID="STR_ACE_Medical_GUI_medicalHintEnabled_justSound">
+            <English>Sound Effect instead of hint</English>
+        </Key>
         <Key ID="STR_ACE_Medical_GUI_medicalHintMedicIcon_Description">
             <English>Image path to display in the medical hint if the player is a medic.</English>
             <Russian>Путь к изображению, которое будет отображаться в медицинской подсказке, если игрок — медик.</Russian>

--- a/addons/quickmount/initSettings.inc.sqf
+++ b/addons/quickmount/initSettings.inc.sqf
@@ -52,3 +52,19 @@ private _category = [ELSTRING(common,ACEKeybindCategoryVehicles), LLSTRING(Categ
         3
     ]
 ] call CBA_fnc_addSetting;
+
+[
+    QGVAR(enable3d),
+    "LIST",
+    [LSTRING(enable3d), LSTRING(enable3d_Description)],
+    _category,
+    [
+        [0,1,2],
+        [
+            ELSTRING(common,Disabled),
+            LSTRING(enable3d_shiftKey),
+            ELSTRING(common,Enabled)
+        ],
+        2
+    ]
+] call CBA_fnc_addSetting;

--- a/addons/quickmount/initSettings.inc.sqf
+++ b/addons/quickmount/initSettings.inc.sqf
@@ -52,19 +52,3 @@ private _category = [ELSTRING(common,ACEKeybindCategoryVehicles), LLSTRING(Categ
         3
     ]
 ] call CBA_fnc_addSetting;
-
-[
-    QGVAR(enable3d),
-    "LIST",
-    [LSTRING(enable3d), LSTRING(enable3d_Description)],
-    _category,
-    [
-        [0,1,2],
-        [
-            ELSTRING(common,Disabled),
-            LSTRING(enable3d_shiftKey),
-            ELSTRING(common,Enabled)
-        ],
-        2
-    ]
-] call CBA_fnc_addSetting;


### PR DESCRIPTION
ref #10883 Tag @DartRuffian for feedback

changes  `medicalHintEnabled` setting to be a choice between
- disabled
- new hint (default)
- just sound effect

Change the setting to be user (feature can still be disabled by server/mission forcing)
This lets the receiver decide if they want to see the hint (which some may find immersion-breaking)

Sound effect is a very short medical clinking
Could make the sound effect always play if desired?
