### PR TITLE
COMPAT CWR3 BAF - Add SACLOS to Javelin SAM and MCLOS to Blowpipe SAM

### DIFF
--- a/addons/compat_cwr3_baf/CfgAmmo.hpp
+++ b/addons/compat_cwr3_baf/CfgAmmo.hpp
@@ -1,29 +1,2 @@
 class CfgAmmo {
-    class MissileBase;
-
-    class cwr3_m_javelin_aa: MissileBase {
-        effectsMissile = "missile2"; // Remove vanilla tracking flare, missileguidance adds it's own.
-        thrust = 275;       // Give a more realistic thrust and thrustTime
-        thrustTime = 3;     // Since we don't need it longer for the vanilla flare.
-        timeToLive = 20;
-
-        class ace_missileguidance: ace_missileguidance_type_RBS70 {
-            // SACLOS guidance
-            enabled = 1;
-            lineGainD = 16;
-            lineGainP = 30;
-            seekerMaxRange = 5500;
-            showTrail = 1;
-        };
-    };
-
-    class cwr3_m_blowpipe_aa: cwr3_m_javelin_aa {
-        thrust = 240;
-        thrustTime = 3;
-        class ace_missileguidance: ace_missileguidance_type_Blowpipe {
-            // MCLOS guidance
-            enabled = 1;
-            showTrail = 1;
-        };
-    };
 };

--- a/addons/compat_cwr3_baf/compat_cwr3_baf_missileguidance/CfgAmmo.hpp
+++ b/addons/compat_cwr3_baf/compat_cwr3_baf_missileguidance/CfgAmmo.hpp
@@ -1,0 +1,29 @@
+class CfgAmmo {
+    class MissileBase;
+
+    class cwr3_m_javelin_aa: MissileBase {
+        effectsMissile = "missile2"; // Remove vanilla tracking flare, missileguidance adds it's own.
+        thrust = 275;       // Give a more realistic thrust and thrustTime
+        thrustTime = 3;     // Since we don't need it longer for the vanilla flare.
+        timeToLive = 20;
+
+        class ace_missileguidance: ace_missileguidance_type_RBS70 {
+            // SACLOS guidance
+            enabled = 1;
+            lineGainD = 16;
+            lineGainP = 30;
+            seekerMaxRange = 5500;
+            showTrail = 1;
+        };
+    };
+
+    class cwr3_m_blowpipe_aa: cwr3_m_javelin_aa {
+        thrust = 240;
+        thrustTime = 3;
+        class ace_missileguidance: ace_missileguidance_type_Blowpipe {
+            // MCLOS guidance
+            enabled = 1;
+            showTrail = 1;
+        };
+    };
+};

--- a/addons/compat_cwr3_baf/compat_cwr3_baf_missileguidance/config.cpp
+++ b/addons/compat_cwr3_baf/compat_cwr3_baf_missileguidance/config.cpp
@@ -1,27 +1,25 @@
 #include "script_component.hpp"
 
 class CfgPatches {
-    class ADDON {
+    class SUBADDON {
         name = COMPONENT_NAME;
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {
-            "ace_compat_cwr3",
-            "cwr3_expansion_uk",
-            "cwr3_soldiers_uk"
+            "ace_compat_cwr3_baf",
+            "ace_missileguidance"
         };
         skipWhenMissingDependencies = 1;
         author = ECSTRING(common,ACETeam);
         authors[] = {"CWR3", "drofseh"};
         url = ECSTRING(main,URL);
         VERSION_CONFIG;
+
+        addonRootClass = QUOTE(ADDON);
     };
 };
 
-#include "CfgAmmo.hpp"
-#include "CfgMagazines.hpp"
-#include "CfgWeapons.hpp"
-#include "CfgVehicles.hpp"
+#include "\z\ace\addons\missileguidance\script_missileBases.hpp"
 
-#include "ace_wardrobe.hpp"
+#include "CfgAmmo.hpp"

--- a/addons/compat_cwr3_baf/compat_cwr3_baf_missileguidance/script_component.hpp
+++ b/addons/compat_cwr3_baf/compat_cwr3_baf_missileguidance/script_component.hpp
@@ -1,0 +1,4 @@
+#define SUBCOMPONENT missileguidance
+#define SUBCOMPONENT_BEAUTIFIED Missile Guidance
+
+#include "..\script_component.hpp"

--- a/addons/compat_cwr3_baf/config.cpp
+++ b/addons/compat_cwr3_baf/config.cpp
@@ -19,6 +19,7 @@ class CfgPatches {
     };
 };
 
+#include "\z\ace\addons\missileguidance\script_missileBases.hpp"
 #include "CfgAmmo.hpp"
 #include "CfgMagazines.hpp"
 #include "CfgWeapons.hpp"

--- a/addons/compat_cwr3_baf/config.cpp
+++ b/addons/compat_cwr3_baf/config.cpp
@@ -19,7 +19,7 @@ class CfgPatches {
     };
 };
 
-// #include "CfgAmmo.hpp" // Uncomment when CWR3 updates
+#include "CfgAmmo.hpp"
 #include "CfgMagazines.hpp"
 #include "CfgWeapons.hpp"
 #include "CfgVehicles.hpp"


### PR DESCRIPTION
**When merged this pull request will:**
- unlock the missile guidance config added in #11054 now that CWR3 has updated and the classes exist.
- moved to subaddon as requested

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
