### PR TITLE
Refuel - Fix `destrType`

### DIFF
--- a/addons/refuel/CfgVehicles.hpp
+++ b/addons/refuel/CfgVehicles.hpp
@@ -554,7 +554,7 @@ class CfgVehicles {
         EGVAR(cargo,hasCargo) = 0;
         EGVAR(cargo,space) = 0;
         damageEffect = "";
-        destrType = "";
+        destrType = "DestructNo";
         class HitPoints {};
         class Turrets {};
         class TransportItems {};


### PR DESCRIPTION
seems to be source of
(this may only show with `-debug`?)
```
Warning: Cannot evaluate ''
âž¥ Context: bin\config.bin/CfgVehicles/ace_refuel_helper.ace_refuel_helper
->Last modified by: ace_refuel <- 	[] L5 (x\cba\addons\common\XEH_postInit.sqf)
	[] L38 (x\cba\addons\common\init_perFrameHandler.sqf)
	[] L34 (x\cba\addons\common\init_perFrameHandler.sqf)
	[] L36 (x\cba\addons\common\init_perFrameHandler.sqf)
	[] L100 (z\ace\addons\common\functions\fnc_progressBar.sqf)
	[] L116 (z\ace\addons\common\functions\fnc_progressBar.sqf)
	[] L117 (z\ace\addons\common\functions\fnc_progressBar.sqf)
	[] L120 (z\ace\addons\common\functions\fnc_progressBar.sqf)
	[] L35 (z\ace\addons\refuel\functions\fnc_takeNozzle.sqf)
	[] L53 (z\ace\addons\refuel\functions\fnc_takeNozzle.sqf)
	[] L54 (z\ace\addons\refuel\functions\fnc_takeNozzle.sqf)
```

matches https://github.com/acemod/ACE3/pull/9051/changes