### PR TITLE
Recoil - Fix `customShakeCoef` on non-class CfgRecoils

### DIFF
--- a/addons/recoil/functions/fnc_camshake.sqf
+++ b/addons/recoil/functions/fnc_camshake.sqf
@@ -38,14 +38,13 @@ private _recoil = GVAR(recoilCache) getOrDefaultCall [_weapon + _muzzle, {
         getText (_config >> _muzzle >> "recoil")
     };
 
-    private _customShakeCoef = if (isNumber (configFile >> "CfgRecoils" >> _recoil >> QGVAR(customShakeCoef))) then {
-        getNumber (configFile >> "CfgRecoils" >> _recoil >> QGVAR(customShakeCoef))
-    } else {
-        1
-    };
-
+    private _customShakeCoef = 1;
     if (isClass (configFile >> "CfgRecoils" >> _recoil)) then {
         _recoil = getArray (configFile >> "CfgRecoils" >> _recoil >> "kickBack");
+
+        if (isNumber (configFile >> "CfgRecoils" >> _recoil >> QGVAR(customShakeCoef))) then {
+            _customShakeCoef = getNumber (configFile >> "CfgRecoils" >> _recoil >> QGVAR(customShakeCoef));
+        };
 
         if (count _recoil < 2) then {
             _recoil = [0, 0];


### PR DESCRIPTION
shoot cup stinger, get popup error

```
Warning Message: 'recoil_single_titan/' is not a class ('ace_recoil_customShakeCoef' accessed)
âž¥ Context: 	[] L41 (z\ace\addons\recoil\functions\fnc_camshake.sqf)
```

context
```
class CfgRecoils {
	recoil_single_titan[]={0,0,0,0.0099999998,0,0.050000001,0.025,0,0};
```