### PR TITLE
Ballistics - Add `B_12Gauge_Pellets_Submunition` AB values

### DIFF
--- a/addons/ballistics/CfgAmmo.hpp
+++ b/addons/ballistics/CfgAmmo.hpp
@@ -116,12 +116,12 @@ class CfgAmmo {
         caliber = 0.45;
         hit = 1.46;
     };
-    class ACE_12Gauge_Pellets_Submunition_No3_Buck: B_12Gauge_Pellets_Submunition {
+    class ACE_12Gauge_Pellets_Submunition_No3_Buck: B_12Gauge_Pellets_Submunition { // vanilla Pellets
         ACE_caliber = 6.35; // 0.25"
         ACE_bulletLength = 6.35; // 0.25"
         ACE_bulletMass = 1.516; // 23.4gr
         ACE_ballisticCoefficients[] = {0.038};
-        airFriction = -0.006762; // based on terminal velocities M0.8 272m/s 49m
+        airFriction = -0.006762; // based on terminal velocities M0.8 272m/s 49m, vanilla -0.0005
         caliber = 0.425;
         submunitionAmmo = "ACE_12Gauge_Pellets_Submunition_No3_Buck_Deploy";
         submunitionConeType[] = {"poissondisc", 18};
@@ -132,7 +132,7 @@ class CfgAmmo {
         ACE_bulletLength = 6.35; // 0.25"
         ACE_bulletMass = 1.516; // 23.4gr
         ACE_ballisticCoefficients[] = {0.038};
-        airFriction = -0.006762; // based on terminal velocities M0.8 272m/s 49m
+        airFriction = -0.006762; // based on terminal velocities M0.8 272m/s 49m, vanilla -0.0067
         caliber = 0.425;
         hit = 1.13;
     };

--- a/addons/ballistics/CfgAmmo.hpp
+++ b/addons/ballistics/CfgAmmo.hpp
@@ -1,14 +1,20 @@
 
 class CfgAmmo {
-    class BulletCore;
-
-    class BulletBase: BulletCore {
-        timeToLive=6;
-    };
-
+    class BulletBase;
     class ShotgunBase;
 
-    class B_12Gauge_Pellets_Submunition: BulletBase { //#00 Buckshot
+    class B_12Gauge_Pellets_Submunition: BulletBase { //#00 Buckshot https://en.wikipedia.org/wiki/Shot_(pellet)
+        ACE_caliber = 8.38; // 0.33"
+        ACE_bulletLength = 8.38; // 0.33"
+        ACE_bulletMass = 3.486; // 53.8gr
+        ACE_ballisticCoefficients[] = {0.049}; // ICAO G1 BC estimation based on size, mass and velocity from exterior ballistic app "EBC V2".
+        ACE_dragModel = 1;
+        ACE_velocityBoundaries[] = {};
+        ACE_standardAtmosphere = "ICAO";
+        ACE_ammoTempMuzzleVelocityShifts[] = {-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619}; // default ACE_ammoTempMuzzleVelocityShifts values /10 (Ammo Temp MV Curve Tables by TiborasaurusRex). Muzzle velocity shift 0m/s 70°F (21°C), -1m/s 15°C
+        ACE_muzzleVelocities[] = {265, 343, 372, 381, 403}; // Muzzle Velocities 70°F (21°C, MV 15°C +1m/s), 326m/s (317mm), 332m/s (330.2mm), 340m/s (349.7mm), 378m/s (699.3mm), 380m/s 30" ICAO (15°C, 1013.25 hPa, 0%)
+        ACE_barrelLengths[] = {165.1, 355.6, 546.1, 762, 914.4}; // 6.5, 14, 21.5, 30, 36"
+        airFriction = -0.005307; // based on terminal velocities M0.8 272m/s 63m
         //vanilla values have been left as comments for reference purposes
         caliber = 0.525; //penetration of ~3mm RHA, ~9.6mm metal
         //caliber = 1; //too high, ~5.7mm of RHA (380*1*15/1000=5.7), ~18.25 metal
@@ -17,15 +23,25 @@ class CfgAmmo {
         //simulationStep = 0.0001;
         //cartridge = "";
         //submunitionAmmo = "B_12Gauge_Pellets_Submunition_Deploy";
-        submunitionConeType[] = {"poissondisc", 9};  //#00 Buckshot generally has 9 pellets per shell
+        submunitionConeType[] = {"poissondisc", 8};  //#00 Buckshot generally has 8 pellets per shell
         //submunitionConeType[] = {"poissondisc", 18};
         //submunitionConeAngle = 0.8;
         //triggerSpeedCoef[] = {0.85, 1};
         triggerTime = 0.008; // Shot takes ~5-15 feet to start spreading out and the vanilla triggerTime is too short to allow that
         //triggerTime = 0.001;
     };
-    class B_12Gauge_Pellets_Submunition_Deploy: BulletBase {
-        airFriction = -0.0030;
+    class B_12Gauge_Pellets_Submunition_Deploy: BulletBase { // https://en.wikipedia.org/wiki/Shot_(pellet)
+        ACE_caliber = 8.38; // 0.33"
+        ACE_bulletLength = 8.38; // 0.33"
+        ACE_bulletMass = 3.486; // 53.8gr
+        ACE_ballisticCoefficients[] = {0.049}; // ICAO G1 BC estimation based on size, mass and velocity from exterior ballistic app "EBC V2".
+        ACE_dragModel = 1;
+        ACE_velocityBoundaries[] = {};
+        ACE_standardAtmosphere = "ICAO";
+        ACE_ammoTempMuzzleVelocityShifts[] = {-2.655, -2.547, -2.285, -2.012, -1.698, -1.280, -0.764, -0.153, 0.596, 1.517, 2.619}; // default ACE_ammoTempMuzzleVelocityShifts values /10 (Ammo Temp MV Curve Tables by TiborasaurusRex). Muzzle velocity shift 0m/s 70°F (21°C), -1m/s 15°C
+        ACE_muzzleVelocities[] = {265, 343, 372, 381, 403}; // Muzzle Velocities 70°F (21°C, MV 15°C +1m/s), 326m/s (317mm), 332m/s (330.2mm), 340m/s (349.7mm), 378m/s (699.3mm), 380m/s 30" ICAO (15°C, 1013.25 hPa, 0%)
+        ACE_barrelLengths[] = {165.1, 355.6, 546.1, 762, 914.4}; // 6.5, 14, 21.5, 30, 36"
+        airFriction = -0.005307; // based on terminal velocities M0.8 272m/s 63m
         //airFriction = -0.0067;
         caliber = 0.525;
         hit = 2.55; //vanilla hit is way too high
@@ -41,61 +57,111 @@ class CfgAmmo {
     };
 
     class ACE_12Gauge_Pellets_Submunition_No0_Buck: B_12Gauge_Pellets_Submunition {
+        ACE_caliber = 8.13; // 0.32"
+        ACE_bulletLength = 8.13; // 0.32"
+        ACE_bulletMass = 3.175; // 49gr
+        ACE_ballisticCoefficients[] = {0.048};
+        airFriction = -0.005379; // based on terminal velocities M0.8 272m/s 62m
         caliber = 0.5;
         submunitionAmmo = "ACE_12Gauge_Pellets_Submunition_No0_Buck_Deploy";
         submunitionConeType[] = {"poissondisc", 9};
         submunitionConeAngle = 0.81;
     };
     class ACE_12Gauge_Pellets_Submunition_No0_Buck_Deploy: B_12Gauge_Pellets_Submunition_Deploy {
-        airFriction = -0.0033;
+        ACE_caliber = 8.13; // 0.32"
+        ACE_bulletLength = 8.13; // 0.32"
+        ACE_bulletMass = 3.175; // 49gr
+        ACE_ballisticCoefficients[] = {0.048};
+        airFriction = -0.005379; // based on terminal velocities M0.8 272m/s 62m
         caliber = 0.5;
         hit = 2.27;
     };
     class ACE_12Gauge_Pellets_Submunition_No1_Buck: B_12Gauge_Pellets_Submunition {
+        ACE_caliber = 7.62; // 0.30"
+        ACE_bulletLength = 7.62; // 0.30"
+        ACE_bulletMass = 2.624; // 40.5gr
+        ACE_ballisticCoefficients[] = {0.045};
+        airFriction = -0.005773; // based on terminal velocities M0.8 272m/s 58m
         caliber = 0.475;
         submunitionAmmo = "ACE_12Gauge_Pellets_Submunition_No1_Buck_Deploy";
-        submunitionConeType[] = {"poissondisc", 11};
+        submunitionConeType[] = {"poissondisc", 10};
         submunitionConeAngle = 0.83;
     };
     class ACE_12Gauge_Pellets_Submunition_No1_Buck_Deploy: B_12Gauge_Pellets_Submunition_Deploy {
-        airFriction = -0.0038;
+        ACE_caliber = 7.62; // 0.30"
+        ACE_bulletLength = 7.62; // 0.30"
+        ACE_bulletMass = 2.624; // 40.5gr
+        ACE_ballisticCoefficients[] = {0.045};
+        airFriction = -0.005773; // based on terminal velocities M0.8 272m/s 58m
         caliber = 0.475;
         hit = 1.86;
     };
     class ACE_12Gauge_Pellets_Submunition_No2_Buck: B_12Gauge_Pellets_Submunition {
+        ACE_caliber = 6.86; // 0.27"
+        ACE_bulletLength = 6.86; // 0.27"
+        ACE_bulletMass = 1.905; // 29.4gr
+        ACE_ballisticCoefficients[] = {0.04};
+        airFriction = -0.006538; // based on terminal velocities M0.8 272m/s 51m
         caliber = 0.45;
         submunitionAmmo = "ACE_12Gauge_Pellets_Submunition_No2_Buck_Deploy";
         submunitionConeType[] = {"poissondisc", 14};
         submunitionConeAngle = 0.85;
     };
     class ACE_12Gauge_Pellets_Submunition_No2_Buck_Deploy: B_12Gauge_Pellets_Submunition_Deploy {
-        airFriction = -0.0048;
+        ACE_caliber = 6.86; // 0.27"
+        ACE_bulletLength = 6.86; // 0.27"
+        ACE_bulletMass = 1.905; // 29.4gr
+        ACE_ballisticCoefficients[] = {0.04};
+        airFriction = -0.006538; // based on terminal velocities M0.8 272m/s 51m
         caliber = 0.45;
         hit = 1.46;
     };
     class ACE_12Gauge_Pellets_Submunition_No3_Buck: B_12Gauge_Pellets_Submunition {
+        ACE_caliber = 6.35; // 0.25"
+        ACE_bulletLength = 6.35; // 0.25"
+        ACE_bulletMass = 1.516; // 23.4gr
+        ACE_ballisticCoefficients[] = {0.038};
+        airFriction = -0.006762; // based on terminal velocities M0.8 272m/s 49m
         caliber = 0.425;
         submunitionAmmo = "ACE_12Gauge_Pellets_Submunition_No3_Buck_Deploy";
         submunitionConeType[] = {"poissondisc", 18};
         submunitionConeAngle = 0.87;
     };
     class ACE_12Gauge_Pellets_Submunition_No3_Buck_Deploy: B_12Gauge_Pellets_Submunition_Deploy {
-        airFriction = -0.0067;
+        ACE_caliber = 6.35; // 0.25"
+        ACE_bulletLength = 6.35; // 0.25"
+        ACE_bulletMass = 1.516; // 23.4gr
+        ACE_ballisticCoefficients[] = {0.038};
+        airFriction = -0.006762; // based on terminal velocities M0.8 272m/s 49m
         caliber = 0.425;
         hit = 1.13;
     };
     class ACE_12Gauge_Pellets_Submunition_No4_Buck: B_12Gauge_Pellets_Submunition {
+        ACE_caliber = 6.1; // 0.24"
+        ACE_bulletLength = 6.1; // 0.24"
+        ACE_bulletMass = 1.341; // 20.7gr
+        ACE_ballisticCoefficients[] = {0.036};
+        airFriction = -0.00726; // based on terminal velocities M0.8 272m/s 46m
         caliber = 0.4;
         submunitionAmmo = "ACE_12Gauge_Pellets_Submunition_No4_Buck_Deploy";
         submunitionConeType[] = {"poissondisc", 21};
         submunitionConeAngle = 0.89;
     };
     class ACE_12Gauge_Pellets_Submunition_No4_Buck_Deploy: B_12Gauge_Pellets_Submunition_Deploy {
-        airFriction = -0.0085;
+        ACE_caliber = 6.1; // 0.24"
+        ACE_bulletLength = 6.1; // 0.24"
+        ACE_bulletMass = 1.341; // 20.7gr
+        ACE_ballisticCoefficients[] = {0.036};
+        airFriction = -0.00726; // based on terminal velocities M0.8 272m/s 46m
         caliber = 0.4;
         hit = 0.97;
     };
     class ACE_12Gauge_Pellets_Submunition_No4_Bird: B_12Gauge_Pellets_Submunition {
+        ACE_caliber = 3.3; // 0.13"
+        ACE_bulletLength = 3.3; // 0.13"
+        ACE_bulletMass = 0.21; // 3.24gr
+        ACE_ballisticCoefficients[] = {0.02};
+        airFriction = -0.013447; // based on terminal velocities M0.8 272m/s 25m
         caliber = 0.2;
         hit = 3;
         submunitionAmmo = "ACE_12Gauge_Pellets_Submunition_No4_Bird_Deploy";
@@ -104,8 +170,12 @@ class CfgAmmo {
         triggerSpeedCoef[] = {0.8, 1};
     };
     class ACE_12Gauge_Pellets_Submunition_No4_Bird_Deploy: B_12Gauge_Pellets_Submunition_Deploy {
+        ACE_caliber = 3.3; // 0.13"
+        ACE_bulletLength = 3.3; // 0.13"
+        ACE_bulletMass = 0.21; // 3.24gr
+        ACE_ballisticCoefficients[] = {0.02};
+        airFriction = -0.013447; // based on terminal velocities M0.8 272m/s 25m
         caliber = 0.2;
-        airFriction = -0.0800;
         hit = 0.15;
     };
 

--- a/addons/ballistics/CfgMagazines.hpp
+++ b/addons/ballistics/CfgMagazines.hpp
@@ -53,10 +53,11 @@ class CfgMagazines {
         ammo = "ACE_12Gauge_Pellets_Submunition_No4_Bird";
     };
 
-    class 6Rnd_12Gauge_Pellets: 2Rnd_12Gauge_Pellets {
+    class 6Rnd_12Gauge_Pellets: 2Rnd_12Gauge_Pellets { // arifle_MSBS65_UBS_base_F, arifle_XMS_Shot_lxWS
         displayName = CSTRING(6Rnd_12Gauge_Pellets_No00_Buck_Name);
         displayNameShort = CSTRING(12Gauge_Pellets_No00_Buck_NameShort);
         descriptionShort = CSTRING(12Gauge_Pellets_No00_Buck_Description);
+        initSpeed = 336; // 336x0.971576= 326m/s according to Crye Six12 ACE_muzzleVelocities ICAO conditions (15°C, 1013,25 hPa, 0%), 380
     };
 
     class ACE_6Rnd_12Gauge_Pellets_No0_Buck: 6Rnd_12Gauge_Pellets {

--- a/addons/ballistics/CfgWeapons.hpp
+++ b/addons/ballistics/CfgWeapons.hpp
@@ -141,13 +141,13 @@ class CfgWeapons {
     class sgun_HunterShotgun_01_base_F: Rifle_Long_Base_F {
         ACE_barrelLength = 699.3; // https://www.imfdb.org/wiki/CZ-581
         ACE_twistDirection = 0;
-        initSpeed = -0.99385; // 485m/s according to ACE_muzzleVelocities ASM conditions (15°C, 59°F)
+        initSpeed = -0.99385; // according to ACE_muzzleVelocities ICAO and ASM conditions (15°C, 59°F)
     };
 
     // CZ-581 (sawed off)
     class sgun_HunterShotgun_01_sawedoff_base_F: sgun_HunterShotgun_01_base_F {
         ACE_barrelLength = 349.7; // About half of original length
-        initSpeed = -0.893443; // 436m/s according to ACE_muzzleVelocities ASM conditions (15°C, 59°F)
+        initSpeed = -0.893443; // according to ACE_muzzleVelocities ICAO and ASM conditions (15°C, 59°F)
     };
 
     // Rifle_Base_F

--- a/addons/compat_ws/CfgAmmo.hpp
+++ b/addons/compat_ws/CfgAmmo.hpp
@@ -1,10 +1,19 @@
 
 class CfgAmmo {
     class B_12Gauge_Pellets_Submunition; // #00 Buckshot
+    class B_12Gauge_Slug_NoCartridge; // 488m/s (1600fps, 30") ASM (15°C, 999.916hPa, 78%)
 
     class B_12gauge_Pellets_Cartridge_lxWS: B_12Gauge_Pellets_Submunition {
         submunitionConeType[] = {"poissondisc", 8}; // #00 Buckshot
         // submunitionConeType[] = {"poissondisc", 14}; // No2 Buckshot
         // cartridge = "FxCartridge_12Gauge_Pellet_lxWS";
+    };
+
+    class lxWS_B_SG_HE: B_12Gauge_Slug_NoCartridge { // 380m/s 30" ICAO (15°C, 1013.25 hPa, 0%) according to lxWS HE Mags initSpeed
+        ACE_muzzleVelocities[] = {265, 343, 372, 381, 403}; // Muzzle Velocities 70°F (21°C, MV 15°C +1m/s), 326m/s (317mm), 332m/s (330.2mm), 380m/s 30" ICAO (15°C, 1013.25 hPa, 0%)
+    };
+
+    class lxWS_B_SG_Smoke: B_12Gauge_Slug_NoCartridge { // 380m/s 30" ICAO (15°C, 1013.25 hPa, 0%) according to lxWS Smoke Mags initSpeed
+        ACE_muzzleVelocities[] = {265, 343, 372, 381, 403}; // Muzzle Velocities 70°F (21°C, MV 15°C +1m/s), 326m/s (317mm), 332m/s (330.2mm), 380m/s 30" ICAO (15°C, 1013.25 hPa, 0%)
     };
 };

--- a/addons/compat_ws/CfgAmmo.hpp
+++ b/addons/compat_ws/CfgAmmo.hpp
@@ -1,0 +1,10 @@
+
+class CfgAmmo {
+    class B_12Gauge_Pellets_Submunition; // #00 Buckshot
+
+    class B_12gauge_Pellets_Cartridge_lxWS: B_12Gauge_Pellets_Submunition {
+        submunitionConeType[] = {"poissondisc", 8}; // #00 Buckshot
+        // submunitionConeType[] = {"poissondisc", 14}; // No2 Buckshot
+        // cartridge = "FxCartridge_12Gauge_Pellet_lxWS";
+    };
+};

--- a/addons/compat_ws/CfgMagazines.hpp
+++ b/addons/compat_ws/CfgMagazines.hpp
@@ -1,11 +1,5 @@
 
 class CfgMagazines {
-    class 20Rnd_12Gauge_AA40_Slug_lxWS;
-    class 20Rnd_12Gauge_AA40_Slug_Tan_lxWS;
-    class 20Rnd_12Gauge_AA40_Slug_Snake_lxWS;
-    class 8Rnd_12Gauge_AA40_Slug_lxWS;
-    class 8Rnd_12Gauge_AA40_Slug_Tan_lxWS;
-    class 8Rnd_12Gauge_AA40_Slug_Snake_lxWS;
     class 11Rnd_45ACP_Mag;
 
     class 6rnd_Smoke_Mag_lxWS: 11Rnd_45ACP_Mag {
@@ -22,54 +16,6 @@ class CfgMagazines {
 
     class 2rnd_Smoke_Mag_lxWS: 6rnd_Smoke_Mag_lxWS {
         initSpeed = 380;
-    };
-
-    class ACE_20Rnd_12Gauge_AA40_Slug_lxWS: 20Rnd_12Gauge_AA40_Slug_lxWS {
-        author = ECSTRING(common,ACETeam);
-        displayName = CSTRING(20Rnd_12Gauge_AA40_Slug_lxWS_Name);
-        displayNameShort = CSTRING(20Rnd_12Gauge_Slug_NameShort);
-        ammo = "ACE_12Gauge_Slug_NoCartridge";
-        initSpeed = 610; // according to ACE_muzzleVelocities 12 Gauge SAAMI test barrel 30" ICAO conditions (15°C, 1013,25 hPa, 0%)
-    };
-
-    class ACE_20Rnd_12Gauge_AA40_Slug_Tan_lxWS: 20Rnd_12Gauge_AA40_Slug_Tan_lxWS {
-        author = ECSTRING(common,ACETeam);
-        displayName = CSTRING(20Rnd_12Gauge_AA40_Slug_Tan_lxWS_Name);
-        displayNameShort = CSTRING(20Rnd_12Gauge_Slug_NameShort);
-        ammo = "ACE_12Gauge_Slug_NoCartridge";
-        initSpeed = 610;
-    };
-
-    class ACE_20Rnd_12Gauge_AA40_Slug_Snake_lxWS: 20Rnd_12Gauge_AA40_Slug_Snake_lxWS {
-        author = ECSTRING(common,ACETeam);
-        displayName = CSTRING(20Rnd_12Gauge_AA40_Slug_Snake_lxWS_Name);
-        displayNameShort = CSTRING(20Rnd_12Gauge_Slug_NameShort);
-        ammo = "ACE_12Gauge_Slug_NoCartridge";
-        initSpeed = 610;
-    };
-
-    class ACE_8Rnd_12Gauge_AA40_Slug_lxWS: 8Rnd_12Gauge_AA40_Slug_lxWS {
-        author = ECSTRING(common,ACETeam);
-        displayName = CSTRING(8Rnd_12Gauge_AA40_Slug_lxWS_Name);
-        displayNameShort = CSTRING(20Rnd_12Gauge_Slug_NameShort);
-        ammo = "ACE_12Gauge_Slug_NoCartridge";
-        initSpeed = 610;
-    };
-
-    class ACE_8Rnd_12Gauge_AA40_Slug_Tan_lxWS: 8Rnd_12Gauge_AA40_Slug_Tan_lxWS {
-        author = ECSTRING(common,ACETeam);
-        displayName = CSTRING(8Rnd_12Gauge_AA40_Slug_Tan_lxWS_Name);
-        displayNameShort = CSTRING(20Rnd_12Gauge_Slug_NameShort);
-        ammo = "ACE_12Gauge_Slug_NoCartridge";
-        initSpeed = 610;
-    };
-
-    class ACE_8Rnd_12Gauge_AA40_Slug_Snake_lxWS: 8Rnd_12Gauge_AA40_Slug_Snake_lxWS {
-        author = ECSTRING(common,ACETeam);
-        displayName = CSTRING(8Rnd_12Gauge_AA40_Slug_Snake_lxWS_Name);
-        displayNameShort = CSTRING(20Rnd_12Gauge_Slug_NameShort);
-        ammo = "ACE_12Gauge_Slug_NoCartridge";
-        initSpeed = 610;
     };
 };
 

--- a/addons/compat_ws/CfgMagazines.hpp
+++ b/addons/compat_ws/CfgMagazines.hpp
@@ -1,0 +1,75 @@
+
+class CfgMagazines {
+    class 20Rnd_12Gauge_AA40_Slug_lxWS;
+    class 20Rnd_12Gauge_AA40_Slug_Tan_lxWS;
+    class 20Rnd_12Gauge_AA40_Slug_Snake_lxWS;
+    class 8Rnd_12Gauge_AA40_Slug_lxWS;
+    class 8Rnd_12Gauge_AA40_Slug_Tan_lxWS;
+    class 8Rnd_12Gauge_AA40_Slug_Snake_lxWS;
+    class 11Rnd_45ACP_Mag;
+
+    class 6rnd_Smoke_Mag_lxWS: 11Rnd_45ACP_Mag {
+        initSpeed = 336; // 336x0.971576= 326m/s according to Crye Six12 ACE_muzzleVelocities ICAO conditions (15°C, 1013,25 hPa, 0%), 380
+    };
+
+    class 6rnd_HE_Mag_lxWS: 11Rnd_45ACP_Mag {
+        initSpeed = 336; // 336x0.971576= 326m/s according to Crye Six12 ACE_muzzleVelocities ICAO conditions (15°C, 1013,25 hPa, 0%), 380
+    };
+
+    class 2rnd_HE_Mag_lxWS: 6rnd_HE_Mag_lxWS {
+        initSpeed = 380;
+    };
+
+    class 2rnd_Smoke_Mag_lxWS: 6rnd_Smoke_Mag_lxWS {
+        initSpeed = 380;
+    };
+
+    class ACE_20Rnd_12Gauge_AA40_Slug_lxWS: 20Rnd_12Gauge_AA40_Slug_lxWS {
+        author = ECSTRING(common,ACETeam);
+        displayName = CSTRING(20Rnd_12Gauge_AA40_Slug_lxWS_Name);
+        displayNameShort = CSTRING(20Rnd_12Gauge_Slug_NameShort);
+        ammo = "ACE_12Gauge_Slug_NoCartridge";
+        initSpeed = 610; // according to ACE_muzzleVelocities 12 Gauge SAAMI test barrel 30" ICAO conditions (15°C, 1013,25 hPa, 0%)
+    };
+
+    class ACE_20Rnd_12Gauge_AA40_Slug_Tan_lxWS: 20Rnd_12Gauge_AA40_Slug_Tan_lxWS {
+        author = ECSTRING(common,ACETeam);
+        displayName = CSTRING(20Rnd_12Gauge_AA40_Slug_Tan_lxWS_Name);
+        displayNameShort = CSTRING(20Rnd_12Gauge_Slug_NameShort);
+        ammo = "ACE_12Gauge_Slug_NoCartridge";
+        initSpeed = 610;
+    };
+
+    class ACE_20Rnd_12Gauge_AA40_Slug_Snake_lxWS: 20Rnd_12Gauge_AA40_Slug_Snake_lxWS {
+        author = ECSTRING(common,ACETeam);
+        displayName = CSTRING(20Rnd_12Gauge_AA40_Slug_Snake_lxWS_Name);
+        displayNameShort = CSTRING(20Rnd_12Gauge_Slug_NameShort);
+        ammo = "ACE_12Gauge_Slug_NoCartridge";
+        initSpeed = 610;
+    };
+
+    class ACE_8Rnd_12Gauge_AA40_Slug_lxWS: 8Rnd_12Gauge_AA40_Slug_lxWS {
+        author = ECSTRING(common,ACETeam);
+        displayName = CSTRING(8Rnd_12Gauge_AA40_Slug_lxWS_Name);
+        displayNameShort = CSTRING(20Rnd_12Gauge_Slug_NameShort);
+        ammo = "ACE_12Gauge_Slug_NoCartridge";
+        initSpeed = 610;
+    };
+
+    class ACE_8Rnd_12Gauge_AA40_Slug_Tan_lxWS: 8Rnd_12Gauge_AA40_Slug_Tan_lxWS {
+        author = ECSTRING(common,ACETeam);
+        displayName = CSTRING(8Rnd_12Gauge_AA40_Slug_Tan_lxWS_Name);
+        displayNameShort = CSTRING(20Rnd_12Gauge_Slug_NameShort);
+        ammo = "ACE_12Gauge_Slug_NoCartridge";
+        initSpeed = 610;
+    };
+
+    class ACE_8Rnd_12Gauge_AA40_Slug_Snake_lxWS: 8Rnd_12Gauge_AA40_Slug_Snake_lxWS {
+        author = ECSTRING(common,ACETeam);
+        displayName = CSTRING(8Rnd_12Gauge_AA40_Slug_Snake_lxWS_Name);
+        displayNameShort = CSTRING(20Rnd_12Gauge_Slug_NameShort);
+        ammo = "ACE_12Gauge_Slug_NoCartridge";
+        initSpeed = 610;
+    };
+};
+

--- a/addons/compat_ws/CfgWeapons.hpp
+++ b/addons/compat_ws/CfgWeapons.hpp
@@ -6,7 +6,7 @@ class CfgWeapons {
         ACE_barrelTwist = 0.0;
         ACE_twistDirection = 0;
         ACE_RailHeightAboveBore = 4.99572; // checkScopes.sqf
-        initSpeed = -0.873; // 426m/s according to ACE_muzzleVelocities ASM conditions (15°C, 59°F)
+        initSpeed = -0.873; // according to ACE_muzzleVelocities ICAO and ASM conditions (15°C, 59°F)
     };
 
     // Galat Arm

--- a/addons/compat_ws/config.cpp
+++ b/addons/compat_ws/config.cpp
@@ -19,3 +19,4 @@ class CfgPatches {
 #include "CfgVehicles.hpp"
 #include "CfgWeapons.hpp"
 #include "CfgAmmo.hpp"
+#include "CfgMagazines.hpp"

--- a/addons/compat_ws/config.cpp
+++ b/addons/compat_ws/config.cpp
@@ -18,3 +18,4 @@ class CfgPatches {
 #include "CfgEventHandlers.hpp"
 #include "CfgVehicles.hpp"
 #include "CfgWeapons.hpp"
+#include "CfgAmmo.hpp"


### PR DESCRIPTION
**When merged this pull request will:**
- Add advanced ballistics values to `B_12Gauge_Pellets_Submunition` based on[ Wiki Shot (pellet) data](https://en.wikipedia.org/wiki/Shot_(pellet)).
 - Muzzle velocities (m/s) in-game (AB 15°C 59°F, ICAO ASM):
 
|              | PR DB | PR AB |
|--------------|:-----:|:-----:|
| CZ 581       |  378  |  378  |
| CZ 581 Short |  340  |  340  |
| AA12 (WS)    |  332 |  332  |
| MSBS Grot SG |  326  |  326  |
| XMS SG (WS)  |  326  |  326  |
- Remove vanilla `BulletCore` `timeToLive`.
- [AA12 #00 Buckshot DB - AB Range Card](https://images.steamusercontent.com/ugc/13231654816518256030/C6B03E7442CCBE9B4FA3E4B27CB330D0862797ED/?imw=5000&imh=5000&ima=fit&impolicy=Letterbox&imcolor=%23000000&letterbox=false).
- [CZ 581 #No3 Buckshot DB - AB Range Card](https://images.steamusercontent.com/ugc/14540168170281576827/FCF984EEEC705C58E6BE174029039DCEB943177E/?imw=5000&imh=5000&ima=fit&impolicy=Letterbox&imcolor=%23000000&letterbox=false).
- [CZ 581 Short #No4 Birdshot DB - AB Range Card](https://images.steamusercontent.com/ugc/14053469915734795608/3871E17F752AFBE5362617F60CCBCF2B2A04CA9F/?imw=5000&imh=5000&ima=fit&impolicy=Letterbox&imcolor=%23000000&letterbox=false)

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
