### PR TITLE
Medical Status - Hide inventory & open bag actions when appropriate

### DIFF
--- a/addons/medical_status/functions/fnc_addInventoryActions.sqf
+++ b/addons/medical_status/functions/fnc_addInventoryActions.sqf
@@ -15,6 +15,9 @@
  * Public: No
  */
 
+#define GEAR_ACTION_ENUM 111
+#define OPENBAG_ACTION_ENUM 120
+
 if (!hasInterface) exitWith {};
 
 params ["_unit"];
@@ -26,7 +29,8 @@ private _id = _unit addAction ["", {
     _caller action ["Gear", _target];
 }, nil, 5.1, true, true, "gear", toString {
     (_target isNotEqualTo ACE_player) &&
-    {(lifeState _target) isEqualTo "INCAPACITATED"}
+    {(lifeState _target) isEqualTo "INCAPACITATED"} &&
+    {(hiddenActions [GEAR_ACTION_ENUM]) isEqualTo []}
 }, 2];
 
 _unit setUserActionText [_id, localize "STR_ACTION_GEAR", "<img image='\A3\ui_f\data\igui\cfg\actions\gear_ca.paa' size='2.5' shadow=2 />"];
@@ -42,6 +46,7 @@ _unit addAction ["OpenBag", {
 
     (_target isNotEqualTo ACE_player) &&
     {!((lifeState _target) in ["HEALTHY", "INJURED", "INCAPACITATED"])} &&
+    {(hiddenActions [OPENBAG_ACTION_ENUM]) isEqualTo []} &&
     {!isNull _backpackContainer} &&
     {!lockedInventory _backpackContainer} &&
     {maxLoad _backpackContainer > 0} &&


### PR DESCRIPTION
**When merged this pull request will:**
- Hide `Inventory` and `Open Bag` actions if their "normal" counterparts are hidden using `hideActions`.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
