### PR TITLE
Logistics_Wirecutter - Add: API Function: fnc_hasWirecutter

### DIFF
--- a/addons/logistics_wirecutter/XEH_PREP.hpp
+++ b/addons/logistics_wirecutter/XEH_PREP.hpp
@@ -1,5 +1,5 @@
 PREP(cutDownFence);
 PREP(destroyFence);
+PREP(hasWirecutter);
 PREP(interactEH);
 PREP(isFence);
-PREP(hasWirecutter);

--- a/addons/logistics_wirecutter/XEH_PREP.hpp
+++ b/addons/logistics_wirecutter/XEH_PREP.hpp
@@ -2,3 +2,4 @@ PREP(cutDownFence);
 PREP(destroyFence);
 PREP(interactEH);
 PREP(isFence);
+PREP(hasWirecutter);

--- a/addons/logistics_wirecutter/functions/fnc_cutDownFence.sqf
+++ b/addons/logistics_wirecutter/functions/fnc_cutDownFence.sqf
@@ -63,7 +63,7 @@ if !(_unit call EFUNC(common,isSwimming)) then {
 
         !isNull _fence
         && {damage _fence < 1}
-        && {HAS_WIRECUTTER(_unit)}
+        && {_unit call FUNC(hasWirecutter)}
     },
     ["isNotSwimming"]
 ] call EFUNC(common,progressBar);

--- a/addons/logistics_wirecutter/functions/fnc_hasWirecutter.sqf
+++ b/addons/logistics_wirecutter/functions/fnc_hasWirecutter.sqf
@@ -1,7 +1,7 @@
 #include "..\script_component.hpp"
 /*
  * Author: PabstMirror, OverlordZorn
- * Function to theck if the provided Unit has a wirecutter.
+ * Function to check if the provided Unit has a wirecutter.
  *
  * Arguments:
  * 0: Unit <OBJECT>

--- a/addons/logistics_wirecutter/functions/fnc_hasWirecutter.sqf
+++ b/addons/logistics_wirecutter/functions/fnc_hasWirecutter.sqf
@@ -1,0 +1,22 @@
+#include "..\script_component.hpp"
+/*
+ * Author: PabstMirror, OverlordZorn
+ * Function to theck if the provided Unit has a wirecutter.
+ *
+ * Arguments:
+ * 0: Unit <OBJECT>
+ *
+ * Return Value:
+ * hasWirecutter <BOOL>
+ *
+ * Example:
+ * [cursorObject] call ace_logistics_wirecutter_fnc_hasWirecutter
+ *
+ * Public: yes
+ */
+
+params ["_unit"];
+
+((_unit call EFUNC(common,uniqueItems)) arrayIntersect GVAR(possibleWirecutters)) isNotEqualTo []
+|| {getNumber ((configOf (backpackContainer _unit)) >> QGVAR(hasWirecutter)) == 1}
+|| {getNumber (configFile >> "CfgWeapons" >> (vest _unit) >> QGVAR(hasWirecutter)) == 1}

--- a/addons/logistics_wirecutter/functions/fnc_hasWirecutter.sqf
+++ b/addons/logistics_wirecutter/functions/fnc_hasWirecutter.sqf
@@ -19,4 +19,4 @@ params ["_unit"];
 
 ((_unit call EFUNC(common,uniqueItems)) arrayIntersect GVAR(possibleWirecutters)) isNotEqualTo []
 || {getNumber ((configOf (backpackContainer _unit)) >> QGVAR(hasWirecutter)) == 1}
-|| {getNumber (configFile >> "CfgWeapons" >> (vest _unit) >> QGVAR(hasWirecutter)) == 1}
+|| {getNumber (configFile >> "CfgWeapons" >> (vest _unit) >> QGVAR(hasWirecutter)) == 1} // vestContainer returns something like "Supply140".

--- a/addons/logistics_wirecutter/functions/fnc_interactEH.sqf
+++ b/addons/logistics_wirecutter/functions/fnc_interactEH.sqf
@@ -24,7 +24,7 @@ params ["_interactionType"];
 if (
     _interactionType != 0
     || {!isNull objectParent ACE_player}
-    || {!HAS_WIRECUTTER(ACE_player)}
+    || {! (ACE_player call FUNC(hasWirecutter)) }
 ) exitWith {};
 
 TRACE_1("Starting wirecuter interact PFH",_interactionType);
@@ -53,7 +53,7 @@ TRACE_1("Starting wirecuter interact PFH",_interactionType);
 
                 !isNull _attachedFence
                 && {damage _attachedFence < 1}
-                && {HAS_WIRECUTTER(_player)}
+                && {_player call FUNC(hasWirecutter)}
                 && {[_player, _attachedFence, ["isNotSwimming"]] call EFUNC(common,canInteractWith)}
                 && {
                     // Custom LOS check for fence

--- a/addons/logistics_wirecutter/script_component.hpp
+++ b/addons/logistics_wirecutter/script_component.hpp
@@ -86,9 +86,3 @@
 #define SOUND_CLIP_TIME_SPACING 1.5
 #define CUT_TIME_DEFAULT 11
 #define CUT_TIME_ENGINEER 7.5
-
-#define HAS_WIRECUTTER(unit) (\
-    ((unit call EFUNC(common,uniqueItems)) arrayIntersect GVAR(possibleWirecutters)) isNotEqualTo []\
-    || {getNumber ((configOf (backpackContainer unit)) >> QGVAR(hasWirecutter)) == 1} \
-    || {getNumber (configFile >> "CfgWeapons" >> (vest unit) >> QGVAR(hasWirecutter)) == 1} \
-)


### PR DESCRIPTION
**When merged this pull request will:**
- rm wirecutter macro
- add fnc_hasWirecutter
- use fnc_hasWirecutter inplace of macro

For a project of mine, i would like to use this function as api instead of having to write it myself