### PR TITLE
Javelin - Allow dumb firing certain missiles

### DIFF
--- a/addons/javelin/XEH_preInit.sqf
+++ b/addons/javelin/XEH_preInit.sqf
@@ -12,9 +12,12 @@ GVAR(pfehID) = -1;
 DFUNC(disableFire) = {
     params ["_firedEH"];
 
-    if (_firedEH < 0 && {difficulty > 0}) then {
+    if (_firedEH < 0 && {difficulty > 0} && {
+        private _ammo = getText (configFile >> "CfgMagazines" >> currentMagazine ACE_player >> "ammo");
+        getNumber (configFile >> "CfgAmmo" >> _ammo >> QEGVAR(missileguidance,allowDumbFire)) == 0;
+    }) then {
         _firedEH = [ACE_player, "DefaultAction", {true}, {
-            private _canFire = (_this select 1) getVariable ["ace_missileguidance_target", nil];
+            private _canFire = (_this select 1) getVariable [QEGVAR(missileguidance,target), nil];
             if (!isNil "_canFire") exitWith { false };
             true
         }] call EFUNC(common,addActionEventHandler);

--- a/addons/javelin/XEH_preInit.sqf
+++ b/addons/javelin/XEH_preInit.sqf
@@ -12,10 +12,7 @@ GVAR(pfehID) = -1;
 DFUNC(disableFire) = {
     params ["_firedEH"];
 
-    if (_firedEH < 0 && {difficulty > 0} && {
-        private _ammo = getText (configFile >> "CfgMagazines" >> currentMagazine ACE_player >> "ammo");
-        getNumber (configFile >> "CfgAmmo" >> _ammo >> QEGVAR(missileguidance,allowDumbFire)) == 0;
-    }) then {
+    if (_firedEH < 0 && {difficulty > 0}) then {
         _firedEH = [ACE_player, "DefaultAction", {true}, {
             private _canFire = (_this select 1) getVariable [QEGVAR(missileguidance,target), nil];
             if (!isNil "_canFire") exitWith { false };

--- a/addons/javelin/functions/fnc_onOpticDraw.sqf
+++ b/addons/javelin/functions/fnc_onOpticDraw.sqf
@@ -41,8 +41,8 @@ private _weaponEnabledConfig = _weaponConfig >> QGVAR(enabled);
 private _ammoConfig = [];
 
 // Only consider weapons with explicit enable configs (inheritance not allowed)
+private _ammoType = getText (configFile >> "CfgMagazines" >> _currentMagazine >> "ammo");
 if (_weaponConfig == inheritsFrom _weaponEnabledConfig) then {
-    private _ammoType = getText (configFile >> "CfgMagazines" >> _currentMagazine >> "ammo");
     _ammoConfig = "configName _x == 'ace_missileguidance'" configClasses (configFile >> "CfgAmmo" >> _ammoType);
 } else {
     // If weapon enable is inherited, mark as invalid
@@ -52,7 +52,8 @@ if (_weaponConfig == inheritsFrom _weaponEnabledConfig) then {
 // Check if loaded and javelin enabled for wepaon and missile guidance enabled for loaded ammo
 if ((_ammoCount == 0) || // No ammo loaded
         {(getNumber _weaponEnabledConfig) != 1} || // Not enabled for weapon
-        {_ammoConfig isEqualTo []} || {(getNumber ((_ammoConfig select 0) >> "enabled")) != 1} // Not enabled for ammo
+        {_ammoConfig isEqualTo []} || {(getNumber ((_ammoConfig select 0) >> "enabled")) != 1} || // Not enabled for ammo
+        { getNumber (configFile >> "CfgAmmo" >> _ammoType >> QEGVAR(missileguidance,allowDumbFire)) == 1 } // Allows firing without lock
         ) exitWith {
 
     __JavelinIGUITargeting ctrlShow false;


### PR DESCRIPTION
**When merged this pull request will:**
- Add a property to allow dumb firing certain missiles
  - Personal use case is having missiles use SACLOS / some other mode depending on if the weapon was locked onto something

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
