### PR TITLE
Common - Fix potential leak on cachedCall

### DIFF
--- a/addons/common/functions/fnc_cachedCall.sqf
+++ b/addons/common/functions/fnc_cachedCall.sqf
@@ -9,7 +9,7 @@
  * 2: Namespace (any type that supports setVariable) to store the cache on <ANY>
  * 3: Cache uid <STRING>
  * 4: Max duration of the cache <NUMBER>
- * 5: Events that clear the cache <STRING or ARRAY of STRINGs> (default: nil)
+ * 5: Events that clear the cache <STRING or ARRAY of STRINGs> (default: [])
  *
  * Return Value:
  * Result of the function <ANY>
@@ -20,53 +20,51 @@
  * Public: No
  */
 
-params ["_params", "_function", "_namespace", "_uid", "_duration", "_events"];
+params ["_params", "_function", "_namespace", "_uid", "_duration", ["_events", []]];
 
 // What it was listed on is kept with the cache, so an expiry does not lose it but the erase that
 // empties the lists does
 (_namespace getVariable [_uid, [-99999]]) params ["_expiry", "", ["_listedOn", []]];
 
 if (_expiry < diag_tickTime) then {
-    // Does the cache need to be cleared on an event?
-    if (!isNil "_events") then {
-        if (_events isEqualType "") then {
-            _events = [_events];
-        };
+    if (_events isEqualType "") then {
+        _events = [_events];
+    };
 
-        // Only list it once, rather than again on every recompute
-        if (_listedOn isNotEqualTo _events) then {
-            {
-                private _event = _x;
-                private _varName = format [QGVAR(clearCache_%1), _event];
-                private _cacheList = missionNamespace getVariable _varName;
+    // Does the cache need clearing on an event? Only listed once, not again on every recompute.
+    // No events leaves both of these empty, so nothing is listed
+    if (_listedOn isNotEqualTo _events) then {
+        {
+            private _event = _x;
+            private _varName = format [QGVAR(clearCache_%1), _event];
+            private _cacheList = missionNamespace getVariable _varName;
 
-                // If there was no EH to clear these caches, add one
-                if (isNil "_cacheList") then {
-                    _cacheList = [];
-                    missionNamespace setVariable [_varName, _cacheList];
+            // If there was no EH to clear these caches, add one
+            if (isNil "_cacheList") then {
+                _cacheList = [];
+                missionNamespace setVariable [_varName, _cacheList];
 
-                    [_event, {
-                        #ifdef DEBUG_MODE_FULL
-                            INFO_1("Clear cached variables on event: %1",_eventName);
-                        #endif
-                        // Get the list of caches to clear
-                        //IGNORE_PRIVATE_WARNING ["_eventName"];
-                        // _eventName is defined on the function that calls the event
-                        private _varName = format [QGVAR(clearCache_%1), _eventName];
-                        private _cacheList = missionNamespace getVariable [_varName, []];
-                        // Erase all the cached results
-                        {
-                            _x call FUNC(eraseCache);
-                        } forEach _cacheList;
-                        // Empty the list
-                        missionNamespace setVariable [_varName, []];
-                    }] call CBA_fnc_addEventHandler;
-                };
+                [_event, {
+                    #ifdef DEBUG_MODE_FULL
+                        INFO_1("Clear cached variables on event: %1",_eventName);
+                    #endif
+                    // Get the list of caches to clear
+                    //IGNORE_PRIVATE_WARNING ["_eventName"];
+                    // _eventName is defined on the function that calls the event
+                    private _varName = format [QGVAR(clearCache_%1), _eventName];
+                    private _cacheList = missionNamespace getVariable [_varName, []];
+                    // Erase all the cached results
+                    {
+                        _x call FUNC(eraseCache);
+                    } forEach _cacheList;
+                    // Empty the list
+                    missionNamespace setVariable [_varName, []];
+                }] call CBA_fnc_addEventHandler;
+            };
 
-                // Add this cache to the list of the event
-                _cacheList pushBack [_namespace, _uid];
-            } forEach _events;
-        };
+            // Add this cache to the list of the event
+            _cacheList pushBack [_namespace, _uid];
+        } forEach _events;
     };
 
     _namespace setVariable [_uid, [diag_tickTime + _duration, _params call _function, _events]];

--- a/addons/common/functions/fnc_cachedCall.sqf
+++ b/addons/common/functions/fnc_cachedCall.sqf
@@ -22,45 +22,54 @@
 
 params ["_params", "_function", "_namespace", "_uid", "_duration", "_events"];
 
-if ((_namespace getVariable [_uid, [-99999]]) select 0 < diag_tickTime) then {
-    _namespace setVariable [_uid, [diag_tickTime + _duration, _params call _function]];
+// What it was listed on is kept with the cache, so an expiry does not lose it but the erase that
+// empties the lists does
+(_namespace getVariable [_uid, [-99999]]) params ["_expiry", "", ["_listedOn", []]];
 
+if (_expiry < diag_tickTime) then {
     // Does the cache need to be cleared on an event?
     if (!isNil "_events") then {
         if (_events isEqualType "") then {
             _events = [_events];
         };
-        {
-            private _event = _x;
-            private _varName = format [QGVAR(clearCache_%1), _event];
-            private _cacheList = missionNamespace getVariable _varName;
 
-            // If there was no EH to clear these caches, add one
-            if (isNil "_cacheList") then {
-                _cacheList = [];
-                missionNamespace setVariable [_varName, _cacheList];
+        // Only list it once, rather than again on every recompute
+        if (_listedOn isNotEqualTo _events) then {
+            {
+                private _event = _x;
+                private _varName = format [QGVAR(clearCache_%1), _event];
+                private _cacheList = missionNamespace getVariable _varName;
 
-                [_event, {
-                    #ifdef DEBUG_MODE_FULL
-                        INFO_1("Clear cached variables on event: %1",_eventName);
-                    #endif
-                    // Get the list of caches to clear
-                    //IGNORE_PRIVATE_WARNING ["_eventName"];
-                    // _eventName is defined on the function that calls the event
-                    private _varName = format [QGVAR(clearCache_%1), _eventName];
-                    private _cacheList = missionNamespace getVariable [_varName, []];
-                    // Erase all the cached results
-                    {
-                        _x call FUNC(eraseCache);
-                    } forEach _cacheList;
-                    // Empty the list
-                    missionNamespace setVariable [_varName, []];
-                }] call CBA_fnc_addEventHandler;
-            };
-            // Add this cache to the list of the event
-            _cacheList pushBack [_namespace, _uid];
-        } forEach _events;
+                // If there was no EH to clear these caches, add one
+                if (isNil "_cacheList") then {
+                    _cacheList = [];
+                    missionNamespace setVariable [_varName, _cacheList];
+
+                    [_event, {
+                        #ifdef DEBUG_MODE_FULL
+                            INFO_1("Clear cached variables on event: %1",_eventName);
+                        #endif
+                        // Get the list of caches to clear
+                        //IGNORE_PRIVATE_WARNING ["_eventName"];
+                        // _eventName is defined on the function that calls the event
+                        private _varName = format [QGVAR(clearCache_%1), _eventName];
+                        private _cacheList = missionNamespace getVariable [_varName, []];
+                        // Erase all the cached results
+                        {
+                            _x call FUNC(eraseCache);
+                        } forEach _cacheList;
+                        // Empty the list
+                        missionNamespace setVariable [_varName, []];
+                    }] call CBA_fnc_addEventHandler;
+                };
+
+                // Add this cache to the list of the event
+                _cacheList pushBack [_namespace, _uid];
+            } forEach _events;
+        };
     };
+
+    _namespace setVariable [_uid, [diag_tickTime + _duration, _params call _function, _events]];
 
 #ifdef DEBUG_MODE_FULL
     INFO_2("Calculated result: %1 %2",_namespace,_uid);


### PR DESCRIPTION
**When merged this pull request will:**
- Fix `cachedCall` adding a cache to its event's clear list on every recompute rather than once. The list is only emptied when the event fires, so a cache whose expiry is shorter than the gap between firings adds an entry per expiry until it does.

Would leak when short expiry combined with rare event. Not the case for existing usages but #11450 may hit it.

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
