### PR TITLE
Common - Fix getDLC ids for `Orange`

### DIFF
--- a/addons/common/functions/fnc_getDLC.sqf
+++ b/addons/common/functions/fnc_getDLC.sqf
@@ -52,7 +52,7 @@ private _name = switch (_id) do {
     case "601670": { "Jets" };
     case "288520": { "Kart" };
     case "332350": { "Mark" };
-    case "288520": { "Orange" };
+    case "571710": { "Orange" };
     case "744950": { "Tacops" };
     case "798390": { "Tank" };
     case "1042220": { "GM" };


### PR DESCRIPTION
ref https://github.com/BrettMayson/HEMTT/pull/1322
```
help[L-S52]: Duplicate case `"288520"` in switch statement
   ┌─ addons/common/functions/fnc_getDLC.sqf:55:10
   │
53 │     case "288520": { "Kart" };
   │          --------- first case here
54 │     case "332350": { "Mark" };
55 │     case "288520": { "Orange" };
   │          ^^^^^^^^ duplicate case
```

https://community.bistudio.com/wiki/Category:Arma_3:_DLCs_%26_Expansions

