### PR TITLE
Arsenal - Add generic itemsChanged event

### DIFF
--- a/addons/arsenal/XEH_PREP.hpp
+++ b/addons/arsenal/XEH_PREP.hpp
@@ -41,6 +41,8 @@ PREP(fillLeftPanel);
 PREP(fillLoadoutsList);
 PREP(fillRightPanel);
 PREP(fillSort);
+PREP(fireItemsChangedEvent);
+PREP(getLoadoutItemCounts);
 PREP(getVirtualItems);
 PREP(handleActions);
 PREP(handleLoadoutsSearchbar);

--- a/addons/arsenal/functions/fnc_buttonCargo.sqf
+++ b/addons/arsenal/functions/fnc_buttonCargo.sqf
@@ -28,10 +28,17 @@ if (_add && {_isUnique}) exitWith {};
 private _containerItems = [];
 private _item = _ctrlList lnbData [_lnbCurSel, 0];
 
+// Requesting 5 doesn't guarantee 5 actually move (the container might not fit 5,
+// or might hold fewer than 5 to remove), so the real delta gets measured after
+// rather than assumed from the request - see the end of this switch and below it.
+private _beforeCount = 0;
+
 // Update item count and currentItems array & get relevant container
 private _container = switch (GVAR(currentLeftPanel)) do {
     // Uniform
     case IDC_buttonUniform: {
+        _beforeCount = {_item == _x} count uniformItems GVAR(center);
+
         if (_add) then {
             for "_i" from 1 to ([1, 5] select GVAR(shiftState)) do {
                 GVAR(center) addItemToUniform _item;
@@ -60,6 +67,8 @@ private _container = switch (GVAR(currentLeftPanel)) do {
     };
     // Vest
     case IDC_buttonVest: {
+        _beforeCount = {_item == _x} count vestItems GVAR(center);
+
         if (_add) then {
             for "_i" from 1 to ([1, 5] select GVAR(shiftState)) do {
                 GVAR(center) addItemToVest _item;
@@ -88,6 +97,8 @@ private _container = switch (GVAR(currentLeftPanel)) do {
     };
     // Backpack
     case IDC_buttonBackpack: {
+        _beforeCount = {_item == _x} count backpackItems GVAR(center);
+
         if (_add) then {
             for "_i" from 1 to ([1, 5] select GVAR(shiftState)) do {
                 GVAR(center) addItemToBackpack _item;
@@ -117,9 +128,17 @@ private _container = switch (GVAR(currentLeftPanel)) do {
 };
 
 // Find out how many items of that type there are and update the number displayed
-_ctrlList lnbSetText [[_lnbCurSel, 2], str ({_item == _x} count _containerItems)];
+private _afterCount = {_item == _x} count _containerItems;
+_ctrlList lnbSetText [[_lnbCurSel, 2], str _afterCount];
 
 [QGVAR(cargoChanged), [_display, _item, _addOrRemove, GVAR(shiftState)]] call CBA_fnc_localEvent;
+
+private _oldCounts = createHashMap;
+_oldCounts set [_item, _beforeCount];
+private _newCounts = createHashMap;
+_newCounts set [_item, _afterCount];
+
+[_display, GVAR(currentLeftPanel), _oldCounts, _newCounts] call FUNC(fireItemsChangedEvent);
 
 // Refresh availibility of items based on space remaining in container
 [_ctrlList, _container, _containerItems isNotEqualTo []] call FUNC(updateRightPanel);

--- a/addons/arsenal/functions/fnc_buttonClearAll.sqf
+++ b/addons/arsenal/functions/fnc_buttonClearAll.sqf
@@ -15,6 +15,8 @@
 
 params ["_display"];
 
+private _oldItemCounts = call FUNC(getLoadoutItemCounts);
+
 // Clear chosen container, reset currentItems for that container and get relevant container
 private _container = switch (GVAR(currentLeftPanel)) do {
     // Uniform
@@ -68,3 +70,5 @@ for "_lbIndex" from 0 to (lbSize _ctrlList) - 1 do {
 
 // Refresh availibility of items based on space remaining in container
 [_ctrlList, _container, false] call FUNC(updateRightPanel);
+
+[_display, GVAR(currentLeftPanel), _oldItemCounts, call FUNC(getLoadoutItemCounts)] call FUNC(fireItemsChangedEvent);

--- a/addons/arsenal/functions/fnc_buttonImport.sqf
+++ b/addons/arsenal/functions/fnc_buttonImport.sqf
@@ -59,7 +59,9 @@ if (GVAR(shiftState) && {is3DEN}) then {
         // Since verification nests the extended loadout array, undo that after container recovery
         _extendedLoadout = ([GVAR(center), _extendedLoadout] call FUNC(recoverInvalidContainers)) select 0;
 
+        private _oldItemCounts = call FUNC(getLoadoutItemCounts);
         [GVAR(center), _extendedLoadout] call CBA_fnc_setLoadout;
+        [_display, -1, _oldItemCounts, call FUNC(getLoadoutItemCounts)] call FUNC(fireItemsChangedEvent);
 
         // Update current item list and unique items
         [true] call FUNC(refresh);

--- a/addons/arsenal/functions/fnc_buttonLoadoutsLoad.sqf
+++ b/addons/arsenal/functions/fnc_buttonLoadoutsLoad.sqf
@@ -35,7 +35,10 @@ private _extendedLoadout = switch (GVAR(currentLoadoutsTab)) do {
 };
 
 // Apply loadout to unit
+private _oldItemCounts = call FUNC(getLoadoutItemCounts);
 [GVAR(center), _extendedLoadout, true] call CBA_fnc_setLoadout;
+
+[_display, -1, _oldItemCounts, call FUNC(getLoadoutItemCounts)] call FUNC(fireItemsChangedEvent);
 
 // Prevent overloading of inventory containers
 GVAR(center) call FUNC(preventOverfilling);

--- a/addons/arsenal/functions/fnc_fireItemsChangedEvent.sqf
+++ b/addons/arsenal/functions/fnc_fireItemsChangedEvent.sqf
@@ -1,0 +1,41 @@
+#include "..\script_component.hpp"
+/*
+ * Author: LinkIsGrim
+ * Diffs two classname -> count HashMaps (as returned by FUNC(getLoadoutItemCounts))
+ * and fires QGVAR(itemsChanged) with what actually changed, if anything did.
+ *
+ * Arguments:
+ * 0: Arsenal display <DISPLAY>
+ * 1: Panel the change originated from (an IDC_button* constant) <NUMBER>
+ * 2: Item counts before the change, classname -> count <HASHMAP>
+ * 3: Item counts after the change, classname -> count <HASHMAP>
+ *
+ * Return Value:
+ * None
+ *
+ * Public: No
+*/
+
+params [
+    ["_display", displayNull, [displayNull]],
+    ["_panel", -1, [0]],
+    ["_oldCounts", createHashMap, [createHashMap]],
+    ["_newCounts", createHashMap, [createHashMap]]
+];
+
+private _added = +_newCounts;
+{
+    private _remaining = (_added getOrDefault [_x, 0]) - _y;
+    if (_remaining > 0) then {_added set [_x, _remaining]} else {_added deleteAt _x};
+} forEach _oldCounts;
+
+private _removed = +_oldCounts;
+{
+    private _remaining = (_removed getOrDefault [_x, 0]) - _y;
+    if (_remaining > 0) then {_removed set [_x, _remaining]} else {_removed deleteAt _x};
+} forEach _newCounts;
+
+if (count _added == 0 && {count _removed == 0}) exitWith {};
+
+// QGVAR(itemsChanged): [_display, _panel, _newItem (gained), _oldItem (lost)]
+[QGVAR(itemsChanged), [_display, _panel, _added, _removed]] call CBA_fnc_localEvent;

--- a/addons/arsenal/functions/fnc_getLoadoutItemCounts.sqf
+++ b/addons/arsenal/functions/fnc_getLoadoutItemCounts.sqf
@@ -1,0 +1,78 @@
+#include "..\script_component.hpp"
+#include "..\defines.hpp"
+/*
+ * Author: LinkIsGrim
+ * Flattens GVAR(center)'s current loadout into a classname -> count HashMap - every
+ * weapon, attachment, magazine, worn container's contents, and assigned/linked item.
+ * Used by FUNC(fireItemsChangedEvent) to diff the arsenal's state before and after
+ * a change.
+ *
+ * Deliberately does not include cosmetic-only slots (face, voice, insignia) - they
+ * don't pull from the virtual item pool the way everything else here does.
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * Classname -> count <HASHMAP>
+ *
+ * Example:
+ * call FUNC(getLoadoutItemCounts)
+ *
+ * Public: No
+*/
+
+private _counts = createHashMap;
+
+private _fnc_add = {
+    params [["_class", "", [""]], ["_amount", 1, [0]]];
+    if (_class == "" || {_amount == 0}) exitWith {};
+    _counts set [_class, (_counts getOrDefault [_class, 0]) + _amount];
+};
+
+// Weapon-format slot: [type, muzzle, pointer, optic, [primary mag, ammo],
+// [secondary mag, ammo], bipod] - shared by primary/secondary/handgun/binocular.
+private _fnc_addWeaponSlot = {
+    params [["_slot", [], [[]]]];
+    _slot params [
+        ["_weapon", "", [""]], ["_muzzle", "", [""]], ["_pointer", "", [""]],
+        ["_optic", "", [""]], ["_primaryMag", [], [[]]], ["_secondaryMag", [], [[]]],
+        ["_bipod", "", [""]]
+    ];
+    [_weapon] call _fnc_add;
+    [_muzzle] call _fnc_add;
+    [_pointer] call _fnc_add;
+    [_optic] call _fnc_add;
+    [_primaryMag param [0, ""]] call _fnc_add;
+    [_secondaryMag param [0, ""]] call _fnc_add;
+    [_bipod] call _fnc_add;
+};
+
+// Uniform/vest/backpack slots: [type, [[item, count], [item, count], ...]]
+private _fnc_addContainerSlot = {
+    params [["_slot", [], [[]]]];
+    _slot params [["_container", "", [""]], ["_items", [], [[]]]];
+    [_container] call _fnc_add;
+    {
+        _x params [["_itemClass", "", [""]], ["_itemAmount", 1, [0]]];
+        [_itemClass, _itemAmount] call _fnc_add;
+    } forEach _items;
+};
+
+private _loadout = getUnitLoadout GVAR(center);
+
+[_loadout select IDX_LOADOUT_PRIMARY_WEAPON] call _fnc_addWeaponSlot;
+[_loadout select IDX_LOADOUT_SECONDARY_WEAPON] call _fnc_addWeaponSlot;
+[_loadout select IDX_LOADOUT_HANDGUN_WEAPON] call _fnc_addWeaponSlot;
+[_loadout select IDX_LOADOUT_BINO] call _fnc_addWeaponSlot;
+[_loadout select IDX_LOADOUT_UNIFORM] call _fnc_addContainerSlot;
+[_loadout select IDX_LOADOUT_VEST] call _fnc_addContainerSlot;
+[_loadout select IDX_LOADOUT_BACKPACK] call _fnc_addContainerSlot;
+[_loadout select IDX_LOADOUT_HEADGEAR] call _fnc_add;
+[_loadout select IDX_LOADOUT_GOGGLES] call _fnc_add;
+
+{
+    [_x] call _fnc_add;
+} forEach (_loadout select IDX_LOADOUT_ASSIGNEDITEMS);
+
+_counts

--- a/addons/arsenal/functions/fnc_onSelChangedLeft.sqf
+++ b/addons/arsenal/functions/fnc_onSelChangedLeft.sqf
@@ -20,6 +20,7 @@ params ["_control", "_curSel"];
 if (_curSel < 0) exitWith {};
 
 private _display = ctrlParent _control;
+private _oldItemCounts = call FUNC(getLoadoutItemCounts);
 private _item = [_control lbData _curSel, _control lnbData [_curSel, 0]] select (ctrlType _control == CT_LISTNBOX);
 
 // When having chosen a new category, see if the current right panel can be kept open, otherwise take default
@@ -695,3 +696,5 @@ switch (GVAR(currentLeftPanel)) do {
 };
 
 (_display displayCtrl IDC_totalWeightText) ctrlSetText (format ["%1 (%2)", GVAR(center) call EFUNC(common,getWeight), [GVAR(center), 1] call EFUNC(common,getWeight)]);
+
+[_display, GVAR(currentLeftPanel), _oldItemCounts, call FUNC(getLoadoutItemCounts)] call FUNC(fireItemsChangedEvent);

--- a/addons/arsenal/functions/fnc_onSelChangedRight.sqf
+++ b/addons/arsenal/functions/fnc_onSelChangedRight.sqf
@@ -20,6 +20,7 @@ if (_curSel < 0) exitWith {};
 
 private _display = ctrlParent _control;
 private _item = _control lbData _curSel;
+private _oldItemCounts = call FUNC(getLoadoutItemCounts);
 private _currentItemsIndex = IDX_CURR_PRIMARY_WEAPON_ITEMS + ([IDC_buttonPrimaryWeapon, IDC_buttonSecondaryWeapon, IDC_buttonHandgun, IDC_buttonBinoculars] find GVAR(currentLeftPanel));
 private _itemIndex = [IDC_buttonMuzzle, IDC_buttonItemAcc, IDC_buttonOptic, IDC_buttonBipod, IDC_buttonCurrentMag, IDC_buttonCurrentMag2] find GVAR(currentRightPanel);
 
@@ -207,3 +208,5 @@ switch (_currentItemsIndex) do {
 
 // Update weight display
 (_display displayCtrl IDC_totalWeightText) ctrlSetText (format ["%1 (%2)", GVAR(center) call EFUNC(common,getWeight), [GVAR(center), 1] call EFUNC(common,getWeight)]);
+
+[_display, GVAR(currentRightPanel), _oldItemCounts, call FUNC(getLoadoutItemCounts)] call FUNC(fireItemsChangedEvent);

--- a/docs/wiki/framework/arsenal-framework.md
+++ b/docs/wiki/framework/arsenal-framework.md
@@ -518,6 +518,9 @@ All are local.
 | `ace_arsenal_rightPanelHide` | Arsenal display (DISPLAY) | 3.20.3 |
 | `ace_arsenal_rightPanelWeapon` | Arsenal display (DISPLAY) | 3.20.3 |
 | `ace_arsenal_rightPanelContainer` | Arsenal display (DISPLAY) | 3.20.3 |
+| `ace_arsenal_itemsChanged` | Arsenal display (DISPLAY), panel IDC the change originated from (NUMBER, -1 if not panel-specific e.g. a loadout load/import), items gained (HASHMAP), items lost (HASHMAP) |
+
+`ace_arsenal_itemsChanged`'s items gained/lost HashMaps are keyed by classname, valued by how many of it were gained/lost - a diff, not a full snapshot, so a classname whose count didn't change appears in neither. It fires once for every way an item can enter or leave the arsenal (a weapon/attachment/magazine pick, a container being equipped, the +/- cargo buttons, remove-all/remove-selected, and a whole loadout being loaded or imported), so it's a single place to hook if you need to know what a player actually took or returned - useful for a limited arsenal backed by a real stock (an inventory, an external economy) rather than ACE's own unlimited virtual items.
 
 ## 9. Custom sub item categories
 
@@ -613,3 +616,23 @@ private _loadout = [ACE_player] call CBA_fnc_getLoadout; // or getUnitLoadout AC
 private _replaceExisting = true; // optional, default: false
 ["Current Loadout", _loadout, _replaceExisting] call ace_arsenal_fnc_saveLoadout;
 ```
+
+### 10.5 Reacting to items being taken or returned
+
+`ace_arsenal_itemsChanged` fires once for every way an item can enter or leave the arsenal - see section 8. The following prints what was taken and what was returned every time the player changes anything:
+
+```sqf
+["ace_arsenal_itemsChanged", {
+    params ["_display", "_panel", "_newItems", "_oldItems"];
+
+    {
+        systemChat format ["Took %1x %2", _y, _x];
+    } forEach _newItems;
+
+    {
+        systemChat format ["Returned %1x %2", _y, _x];
+    } forEach _oldItems;
+}] call CBA_fnc_addEventHandler;
+```
+
+This is the primitive a limited/pooled arsenal (backed by a real inventory, or an external economy) needs: instead of diffing the unit's loadout before and after every possible panel interaction yourself, listen for this one event and charge or credit your own stock by exactly what it reports.


### PR DESCRIPTION
Adds QGVAR(itemsChanged), fired as [_display, _panel, _newItem, _oldItem] where _newItem/_oldItem are classname -> count HashMaps of what was gained/lost.

Intended as a single generic replacement for piecing together cargoChanged/weaponItemChanged/leftPanelFilled/rightPanelFilled plus manual ButtonClick hooks on the remove-all buttons to figure out "what did the player just take or return," which is what any limited/pooled virtual arsenal (e.g. an inventory- or external-economy-backed one) needs.

Covers every place items can move in or out of the arsenal:
- fnc_onSelChangedLeft.sqf / fnc_onSelChangedRight.sqf: snapshot the unit's full item counts (fnc_getLoadoutItemCounts.sqf) before and after the existing selection-change logic runs, diff after. Generic enough to catch cascading side effects (an incompatible weapon swap dropping magazines, the primary/secondary magazine swap case) without needing to touch each case individually.
- fnc_buttonCargo.sqf: fires directly as the exact classname and amount are already known here.
- fnc_buttonClearAll.sqf: same snapshot/diff approach, since it clears a container via three different commands depending on container type.
- fnc_buttonLoadoutsLoad.sqf / fnc_buttonImport.sqf

Not fired from fnc_onArsenalOpen.sqf's or the 3DEN-only branch of fnc_onArsenalClose.sqf's setLoadout calls.

Usecase: https://github.com/LinkIsGrim/antistasi-ace3-arsenal

### IMPORTANT

- If the contribution affects [the documentation](https://github.com/acemod/ACE3/tree/master/docs), please include your changes in this pull request so the documentation will appear on the [website](https://ace3.acemod.org/).
- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
